### PR TITLE
Fix pinned DNS lookup for plugin link downloads

### DIFF
--- a/packages/happy2-server/sources/modules/plugin/packageLinkDownloader.test.ts
+++ b/packages/happy2-server/sources/modules/plugin/packageLinkDownloader.test.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, test, vi } from "vitest";
+
+const request = vi.hoisted(() => vi.fn());
+
+vi.mock("node:https", () => ({ request }));
+
+import { NodePluginPackageLinkDownloader } from "./packageLinkDownloader.js";
+
+describe("NodePluginPackageLinkDownloader", () => {
+    test("returns the pinned address array when Node requests all lookup results", async () => {
+        request.mockImplementation((_url, options, onResponse) => {
+            const handle = new EventEmitter() as EventEmitter & { end(): void };
+            handle.end = () => {
+                options.lookup(
+                    "downloads.example.com",
+                    { all: true },
+                    (
+                        error: Error | null,
+                        addresses: Array<{ address: string; family: number }>,
+                    ) => {
+                        expect(error).toBeNull();
+                        expect(addresses).toEqual([{ address: "93.184.216.34", family: 4 }]);
+
+                        const response = new EventEmitter() as EventEmitter & {
+                            headers: Record<string, string>;
+                            statusCode: number;
+                        };
+                        response.headers = {};
+                        response.statusCode = 200;
+                        onResponse(response);
+                        response.emit("data", Buffer.from("zip"));
+                        response.emit("end");
+                    },
+                );
+            };
+            return handle;
+        });
+
+        const downloader = new NodePluginPackageLinkDownloader({
+            validateForStorage: (url) => url,
+            resolveForDelivery: async (url) => ({
+                url,
+                addresses: [{ address: "93.184.216.34", family: 4 }],
+            }),
+        });
+
+        await expect(
+            downloader.download("https://downloads.example.com/plugin.zip"),
+        ).resolves.toEqual({
+            body: Buffer.from("zip"),
+            url: "https://downloads.example.com/plugin.zip",
+        });
+    });
+});

--- a/packages/happy2-server/sources/modules/plugin/packageLinkDownloader.ts
+++ b/packages/happy2-server/sources/modules/plugin/packageLinkDownloader.ts
@@ -1,4 +1,5 @@
 import { request } from "node:https";
+import type { LookupFunction } from "node:net";
 import type { WebhookUrlPolicy } from "../integrations/ssrf.js";
 
 const MAX_ARCHIVE_BYTES = 20 * 1024 * 1024;
@@ -58,13 +59,16 @@ function downloadPinned(
     signal?: AbortSignal,
 ): Promise<{ body: Buffer; location?: string; statusCode: number }> {
     const url = new URL(input);
+    const lookup: LookupFunction = (_hostname, options, callback) => {
+        if (options.all) callback(null, [address]);
+        else callback(null, address.address, address.family);
+    };
     return new Promise((resolve, reject) => {
         const requestHandle = request(
             url,
             {
                 headers: { accept: "application/zip, application/octet-stream" },
-                lookup: (_hostname, _options, callback) =>
-                    callback(null, address.address, address.family),
+                lookup,
                 signal,
             },
             (response) => {


### PR DESCRIPTION
## Summary
- support Node’s `lookup` callback contract when HTTPS requests set `all: true`
- preserve DNS rebinding protection by returning only the policy-approved pinned address
- add a regression test reproducing the plugin ZIP downloader failure

## Cause
Recent Node HTTPS resolution can request all lookup results. The plugin downloader always returned the legacy `(address, family)` callback shape, so Node interpreted the response as an address array and raised `Invalid IP address: undefined`.

## Verification
- `pnpm --filter happy2-server exec vitest run sources/modules/plugin/packageLinkDownloader.test.ts`
- `pnpm --filter happy2-server typecheck`
- `pnpm exec oxfmt --check packages/happy2-server/sources/modules/plugin/packageLinkDownloader.ts packages/happy2-server/sources/modules/plugin/packageLinkDownloader.test.ts`
- `pnpm --filter happy2-server exec oxlint sources/modules/plugin/packageLinkDownloader.ts sources/modules/plugin/packageLinkDownloader.test.ts`

All pass. The workspace emitted its existing Node >=24 engine warning because this runtime uses Node 22.23.1.