### PR TITLE
Fix agent chat sidebar nesting

### DIFF
--- a/packages/happy2-ui/src/pages/chat/chatSidebarModel.test.ts
+++ b/packages/happy2-ui/src/pages/chat/chatSidebarModel.test.ts
@@ -91,6 +91,7 @@ it("places the default-agent conversation in the agents section and projects dis
         "Build agent",
         agent,
     );
+    const secondAgentChat = projection(chat("second-agent-chat", "dm"), "Review agent", agent);
     const humanChat = projection(
         chat("human-chat", "dm", { unreadCount: 4 }),
         "Grace Hopper",
@@ -103,7 +104,7 @@ it("places the default-agent conversation in the agents section and projects dis
     let activeId = "";
     let sidebar: SidebarSnapshot = {
         status: { type: "ready" },
-        chats: [agentChat, defaultAgentChat, humanChat, channel],
+        chats: [agentChat, secondAgentChat, defaultAgentChat, humanChat, channel],
     };
     const directory: DirectorySnapshot = {
         status: { type: "ready", value: true },
@@ -127,14 +128,25 @@ it("places the default-agent conversation in the agents section and projects dis
     expect(model.sections.map((section) => section.items.map((item) => item.label))).toEqual([
         ["Engineering"],
         ["Grace Hopper"],
-        ["Build agent", "Happy"],
+        ["Happy", "Build agent", "Review agent"],
     ]);
     expect(model.sections[1]!.items[0]).toMatchObject({ unread: true, badge: undefined });
-    expect(model.sections[2]!.items[0]).toMatchObject({ unread: true, badge: 2 });
-    expect(model.sections[2]!.items[1]).toMatchObject({ label: "Happy", unread: true, badge: 1 });
+    expect(model.sections[2]!.items[0]).toMatchObject({
+        label: "Happy",
+        depth: undefined,
+        unread: true,
+        badge: 1,
+    });
+    expect(model.sections[2]!.items[1]).toMatchObject({
+        label: "Build agent",
+        depth: 1,
+        unread: true,
+        badge: 2,
+    });
+    expect(model.sections[2]!.items[2]).toMatchObject({ label: "Review agent", depth: 1 });
     activeId = "agent-chat";
     model = createModel();
-    expect(model.sections[2]!.items[0]).toMatchObject({ unread: false, badge: undefined });
+    expect(model.sections[2]!.items[1]).toMatchObject({ unread: false, badge: undefined });
     const changedAgent = projection(
         { ...agentChat.chat, unreadCount: 8, mentionCount: 3 },
         "Release agent",
@@ -143,15 +155,49 @@ it("places the default-agent conversation in the agents section and projects dis
     activeId = "";
     sidebar = {
         status: { type: "ready" },
-        chats: [changedAgent, defaultAgentChat, humanChat, channel],
+        chats: [changedAgent, secondAgentChat, defaultAgentChat, humanChat, channel],
     };
     model = createModel();
-    expect(model.sections[2]!.items[0]).toMatchObject({
+    expect(model.sections[2]!.items[1]).toMatchObject({
         label: "Release agent",
         unread: true,
         badge: 3,
     });
-    expect(model.sections[2]!.items.map((item) => item.label)).toEqual(["Release agent", "Happy"]);
+    expect(model.sections[2]!.items.map((item) => item.label)).toEqual([
+        "Happy",
+        "Release agent",
+        "Review agent",
+    ]);
+    expect(model.sections[2]!.items.map((item) => item.depth)).toEqual([undefined, 1, 1]);
+});
+
+it("keeps agent conversations top-level when search omits the main chat", () => {
+    const model = chatSidebarModelCreate({
+        user: () => ({ id: "human-1", firstName: "Ada" }),
+        activeConversationId: () => "",
+        search: () => "build",
+        sidebarSnapshot: () => ({
+            status: { type: "ready" },
+            chats: [
+                projection(
+                    chat("happy-chat", "dm", { isDefaultAgentConversation: true }),
+                    "Happy",
+                    happy,
+                ),
+                projection(chat("agent-chat", "dm"), "Build agent", agent),
+            ],
+        }),
+        directorySnapshot: () => ({
+            status: { type: "ready", value: true },
+            users: [],
+            channels: [],
+        }),
+        avatarFor: () => undefined,
+    });
+
+    expect(model.sections.find((section) => section.id === "agents")!.items).toMatchObject([
+        { id: "agent-chat", depth: undefined },
+    ]);
 });
 
 it("nests child channels under their parent, flags archives, and rescues orphaned children", () => {

--- a/packages/happy2-ui/src/pages/chat/chatSidebarModel.ts
+++ b/packages/happy2-ui/src/pages/chat/chatSidebarModel.ts
@@ -74,6 +74,29 @@ export function chatSidebarModelCreate(options: ChatSidebarModelOptions) {
         }
         return items;
     }
+    /**
+     * Keeps every composed agent conversation directly under the server-managed
+     * main conversation. If search removes that main row, matching conversations
+     * stay reachable at the top level instead of appearing as orphaned children.
+     */
+    function agentItems(
+        projections: readonly DeepReadonly<SidebarChatProjection>[],
+        ordered: (
+            values: readonly DeepReadonly<SidebarChatProjection>[],
+        ) => DeepReadonly<SidebarChatProjection>[],
+    ): SidebarItem[] {
+        const agents = projections.filter(
+            (projection) => projection.chat.kind === "dm" && isAgentConversation(projection),
+        );
+        const main = agents.find((projection) => projection.chat.isDefaultAgentConversation);
+        if (!main) return ordered(agents).map((projection) => item(projection));
+        return [
+            item(main),
+            ...ordered(agents.filter((projection) => projection.id !== main.id)).map((projection) =>
+                item(projection, 1),
+            ),
+        ];
+    }
     const sections: SidebarSection[] = (() => {
         const needle = options.search().trim().toLowerCase();
         const projections = chats().filter(
@@ -108,12 +131,7 @@ export function chatSidebarModelCreate(options: ChatSidebarModelOptions) {
                 label: "Agents",
                 action: { icon: "plus", label: "New agent" },
                 empty: { actionLabel: "New agent", description: "No agent chats yet." },
-                items: ordered(
-                    projections.filter(
-                        (projection) =>
-                            projection.chat.kind === "dm" && isAgentConversation(projection),
-                    ),
-                ).map(item),
+                items: agentItems(projections, ordered),
             },
         ];
     })();


### PR DESCRIPTION
## What changed

- keep the server-managed default agent conversation as the root row
- render every additional agent conversation at one consistent child depth
- keep filtered agent conversations reachable at the top level when the root is absent
- add regression coverage for multiple Compose-created conversations

## Why

The sidebar passed its projection helper directly to `Array.map`. The array index was therefore interpreted as the optional nesting depth, causing each newly created Happy conversation to appear progressively deeper even though the backend creates independent chats.

## Validation

- `pnpm --filter happy2-ui exec vitest run src/pages/chat/chatSidebarModel.test.ts`
- `pnpm --filter happy2-ui typecheck`
- `pnpm --filter happy2-ui lint`
- `pnpm --filter happy2-ui format:check`
- `git diff --check`