### PR TITLE
Support initial messages when creating child channels

### DIFF
--- a/packages/happy2-gym/sources/rig/index.ts
+++ b/packages/happy2-gym/sources/rig/index.ts
@@ -218,6 +218,7 @@ export class MockRigDaemon implements AsyncDisposable {
     globalStreamRequestCount = 0;
     sessionEventRequestCount = 0;
     terminalAttachmentCount = 0;
+    private nextSessionCreationFailure?: string;
     terminalAttachmentDisconnectCount = 0;
     sessionStreamRequestCount = 0;
     submissionAttemptCount = 0;
@@ -588,6 +589,10 @@ export class MockRigDaemon implements AsyncDisposable {
         this.runStreams.delete(runId);
     }
 
+    failNextSessionCreation(message = "Mock Rig session creation failed"): void {
+        this.nextSessionCreationFailure = message;
+    }
+
     emitGlobalUpdates(count: number): void {
         const session = this.sessions.values().next().value as MockSession | undefined;
         if (!session) throw new Error("Create a mock Rig session before emitting updates");
@@ -812,6 +817,11 @@ export class MockRigDaemon implements AsyncDisposable {
         if (request.method === "POST" && url.pathname === "/events/trim")
             return this.trimGlobalEvents(request, response);
         if (request.method === "POST" && url.pathname === "/sessions") {
+            if (this.nextSessionCreationFailure) {
+                const error = this.nextSessionCreationFailure;
+                this.nextSessionCreationFailure = undefined;
+                return sendJson(response, 503, { error });
+            }
             const body = await jsonBody(request);
             const effort = typeof body.effort === "string" ? body.effort : "high";
             const modelId = typeof body.modelId === "string" ? body.modelId : MOCK_MODEL_ID;

--- a/packages/happy2-gym/tests/server/agent_plugin_calls_receive_installation_bound_chat_tokens_and_update_current_chat.test.ts
+++ b/packages/happy2-gym/tests/server/agent_plugin_calls_receive_installation_bound_chat_tokens_and_update_current_chat.test.ts
@@ -374,10 +374,63 @@ describe("agent plugin chat capabilities", () => {
         );
         if (!channelMembersTool || !childChannelTool)
             throw new Error("New channel did not receive its channel management tools");
+        const childWithoutMessageCallId = rig.requestExternalToolCall(
+            channelRun.runId,
+            childChannelTool.name,
+            { name: "Feature empty child" },
+        );
+        await waitFor(
+            () =>
+                rig.externalToolCalls.find(({ id }) => id === childWithoutMessageCallId)?.status !==
+                "pending",
+            "child channel creation without a message",
+        );
+        const childWithoutMessage = completedOutput(childWithoutMessageCallId, rig);
+        expect(Array.isArray(childWithoutMessage.sync)).toBe(false);
+        expect(childWithoutMessage.initialMessage).toBeUndefined();
+        expect(rig.submittedRuns).toHaveLength(2);
+
+        const peopleChildCallId = rig.requestExternalToolCall(
+            channelRun.runId,
+            childChannelTool.name,
+            {
+                name: "Feature reference context",
+                initialMessage: {
+                    audience: "people",
+                    text: "Reference material only; do not start implementation.",
+                },
+            },
+        );
+        await waitFor(
+            () =>
+                rig.externalToolCalls.find(({ id }) => id === peopleChildCallId)?.status !==
+                "pending",
+            "people child channel creation",
+        );
+        const peopleChildResolution = completedOutput(peopleChildCallId, rig);
+        const peopleChildChatId = (peopleChildResolution.chat as { id: string }).id;
+        expect(peopleChildResolution.initialMessage).toMatchObject({
+            audience: "people",
+            text: "Reference material only; do not start implementation.",
+        });
+        expect(rig.submittedRuns).toHaveLength(2);
+        expect(
+            (await client.get(`/v0/chats/${peopleChildChatId}/messages`)).json().messages,
+        ).toEqual([
+            expect.objectContaining({
+                audience: "people",
+                text: "Reference material only; do not start implementation.",
+            }),
+        ]);
+
         const childCallId = rig.requestExternalToolCall(channelRun.runId, childChannelTool.name, {
             name: "Feature parallel investigation",
             description: "Shares the implementation workspace with an independent history.",
             agentModelId: "gym/alternate-agent",
+            initialMessage: {
+                audience: "agents",
+                text: "Investigate the feature independently and report findings.",
+            },
         });
         await waitFor(
             () => rig.externalToolCalls.find(({ id }) => id === childCallId)?.status !== "pending",
@@ -393,7 +446,59 @@ describe("agent plugin chat capabilities", () => {
             parentChatId: agentChatId,
             agentModelId: "gym/alternate-agent",
         });
+        expect(childResolution.initialMessage).toMatchObject({
+            audience: "agents",
+            text: "Investigate the feature independently and report findings.",
+        });
+        await waitFor(() => rig.submittedRuns.length === 3, "child channel agent turn");
+        expect((await client.get(`/v0/chats/${childChat.id}/messages`)).json().messages).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    audience: "agents",
+                    text: "Investigate the feature independently and report findings.",
+                }),
+            ]),
+        );
         expect((await server.as(friend).get(`/v0/chats/${childChat.id}`)).statusCode).toBe(200);
+
+        rig.failNextSessionCreation("Deliberate child session failure");
+        const failedChildCallId = rig.requestExternalToolCall(
+            channelRun.runId,
+            childChannelTool.name,
+            {
+                name: "Recoverable child",
+                initialMessage: {
+                    audience: "agents",
+                    text: "This setup must fail before leaving a child behind.",
+                },
+            },
+        );
+        await waitFor(
+            () =>
+                rig.externalToolCalls.find(({ id }) => id === failedChildCallId)?.status !==
+                "pending",
+            "failed child setup",
+        );
+        expect(
+            rig.externalToolCalls.find(({ id }) => id === failedChildCallId)?.resolution,
+        ).toMatchObject({
+            status: "failed",
+            error: { message: "Update failed" },
+        });
+        const retriedChildCallId = rig.requestExternalToolCall(
+            channelRun.runId,
+            childChannelTool.name,
+            { name: "Recoverable child" },
+        );
+        await waitFor(
+            () =>
+                rig.externalToolCalls.find(({ id }) => id === retriedChildCallId)?.status !==
+                "pending",
+            "retried child creation",
+        );
+        const retriedChild = completedOutput(retriedChildCallId, rig).chat as { id: string };
+        expect((await server.as(friend).get(`/v0/chats/${retriedChild.id}`)).statusCode).toBe(200);
+
         const updateCallId = rig.requestExternalToolCall(
             channelRun.runId,
             channelMembersTool.name,
@@ -645,6 +750,7 @@ async function install(client: GymRequestClient): Promise<string> {
             "chats:members:add",
             "chats:members:remove",
             "chats:update",
+            "messages:send",
         ],
     });
     expect(installed.statusCode).toBe(202);

--- a/packages/happy2-plugin-chat-management/happy2.plugin.ts
+++ b/packages/happy2-plugin-chat-management/happy2.plugin.ts
@@ -2,7 +2,7 @@ import { definePluginConfig } from "happy2-plugin-sdk/build";
 
 export default definePluginConfig({
     manifest: {
-        version: "1.3.0",
+        version: "1.3.1",
         displayName: "Chat Management",
         shortName: "chat-management",
         description:
@@ -13,6 +13,7 @@ export default definePluginConfig({
             "chats:members:add",
             "chats:members:remove",
             "chats:update",
+            "messages:send",
         ],
     },
 });

--- a/packages/happy2-plugin-chat-management/package.json
+++ b/packages/happy2-plugin-chat-management/package.json
@@ -1,10 +1,11 @@
 {
     "name": "happy2-plugin-chat-management",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "private": true,
     "type": "module",
     "scripts": {
         "build": "happy2-plugin-build",
+        "test": "vitest run",
         "typecheck": "tsc --project tsconfig.json",
         "format": "oxfmt --write .",
         "format:check": "oxfmt --check .",

--- a/packages/happy2-plugin-chat-management/src/schemas.test.ts
+++ b/packages/happy2-plugin-chat-management/src/schemas.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { childCreateSchema } from "./schemas.js";
+
+describe("child channel creation schema", () => {
+    it.each(["agents", "people"] as const)("accepts an optional %s initial message", (audience) => {
+        expect(
+            childCreateSchema.parse({
+                name: "Parallel work",
+                initialMessage: { audience, text: "Investigate the failing test." },
+            }),
+        ).toEqual({
+            name: "Parallel work",
+            initialMessage: { audience, text: "Investigate the failing test." },
+        });
+    });
+
+    it("keeps initial messages closed, bounded, and optional", () => {
+        expect(childCreateSchema.parse({ name: "Context only" })).toEqual({
+            name: "Context only",
+        });
+        expect(() =>
+            childCreateSchema.parse({
+                name: "Invalid audience",
+                initialMessage: { audience: "everyone", text: "Hello" },
+            }),
+        ).toThrow();
+        expect(() =>
+            childCreateSchema.parse({
+                name: "Empty message",
+                initialMessage: { audience: "people", text: "" },
+            }),
+        ).toThrow();
+        expect(() =>
+            childCreateSchema.parse({
+                name: "Unexpected field",
+                initialMessage: { audience: "people", text: "Hello", extra: true },
+            }),
+        ).toThrow();
+    });
+});

--- a/packages/happy2-plugin-chat-management/src/schemas.ts
+++ b/packages/happy2-plugin-chat-management/src/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from "zod/v4";
+
+export const initialMessageSchema = z.strictObject({
+    text: z
+        .string()
+        .min(1)
+        .max(40_000)
+        .describe("A copied or rephrased opening prompt or informational message."),
+    audience: z
+        .enum(["agents", "people"])
+        .describe("agents starts the current agent; people posts without inference."),
+});
+
+export const childCreateSchema = z.strictObject({
+    name: z.string().min(1).max(100).describe("Child channel title."),
+    description: z
+        .string()
+        .min(1)
+        .max(500)
+        .optional()
+        .describe("Optional child channel description."),
+    agentModelId: z
+        .string()
+        .min(1)
+        .max(128)
+        .optional()
+        .describe("Optional available agent model ID for this child's independent session."),
+    initialMessage: initialMessageSchema.optional(),
+});

--- a/packages/happy2-plugin-chat-management/src/server.test.ts
+++ b/packages/happy2-plugin-chat-management/src/server.test.ts
@@ -1,0 +1,79 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { expect, it, vi } from "vitest";
+
+it("advertises and forwards child-channel initial messages through the real MCP tool", async () => {
+    process.env.HAPPY2_PLUGIN_API_URL = "https://happy.test/plugins/host";
+    process.env.HAPPY2_PLUGIN_API_TOKEN = "runtime-token";
+    const { server } = await import("./server.js");
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+            JSON.stringify({
+                chat: { id: "child-1" },
+                initialMessage: { audience: "agents", text: "Investigate this." },
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const client = new Client({ name: "chat-management-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+        const tool = (await client.listTools()).tools.find(
+            ({ name }) => name === "channel_child_create",
+        );
+        expect(tool?.inputSchema).toMatchObject({
+            type: "object",
+            properties: {
+                initialMessage: {
+                    type: "object",
+                    properties: {
+                        audience: { enum: ["agents", "people"] },
+                        text: { type: "string", minLength: 1, maxLength: 40_000 },
+                    },
+                    required: ["text", "audience"],
+                    additionalProperties: false,
+                },
+            },
+            additionalProperties: false,
+        });
+
+        const result = await client.callTool({
+            name: "channel_child_create",
+            arguments: {
+                name: "Parallel investigation",
+                initialMessage: { audience: "agents", text: "Investigate this." },
+            },
+            _meta: {
+                "happy2/chat": {
+                    id: "parent-1",
+                    token: "chat-token",
+                    triggeredByUserId: "user-1",
+                },
+            },
+        });
+        expect(result).toMatchObject({
+            structuredContent: {
+                chat: { id: "child-1" },
+                initialMessage: { audience: "agents", text: "Investigate this." },
+            },
+        });
+        expect(fetch).toHaveBeenCalledOnce();
+        expect(String(fetch.mock.calls[0]?.[0])).toBe(
+            "https://happy.test/plugins/host/channels/createChildChannel",
+        );
+        const request = fetch.mock.calls[0]?.[1];
+        expect(request).toMatchObject({ method: "POST" });
+        expect(request?.headers).toMatchObject({ "x-happy2-chat-token": "chat-token" });
+        expect(JSON.parse(String(request?.body))).toEqual({
+            name: "Parallel investigation",
+            initialMessage: { audience: "agents", text: "Investigate this." },
+        });
+    } finally {
+        await client.close();
+        await server.close();
+        fetch.mockRestore();
+        delete process.env.HAPPY2_PLUGIN_API_URL;
+        delete process.env.HAPPY2_PLUGIN_API_TOKEN;
+    }
+});

--- a/packages/happy2-plugin-chat-management/src/server.ts
+++ b/packages/happy2-plugin-chat-management/src/server.ts
@@ -8,9 +8,10 @@ import {
     type JsonObject,
 } from "happy2-plugin-sdk/server";
 import { z } from "zod/v4";
+import { childCreateSchema, initialMessageSchema } from "./schemas.js";
 
 const USERS_META_KEY = "happy2/users";
-const server = new McpServer({ name: "happy2-chat-management", version: "1.3.0" });
+export const server = new McpServer({ name: "happy2-chat-management", version: "1.3.1" });
 
 const chatUpdateSchema = z
     .strictObject({
@@ -96,16 +97,6 @@ server.registerTool(
         }),
 );
 
-const initialMessageSchema = z.strictObject({
-    text: z
-        .string()
-        .min(1)
-        .max(40_000)
-        .describe("A copied or rephrased opening prompt or informational message."),
-    audience: z
-        .enum(["agents", "people"])
-        .describe("agents starts the current agent; people posts without inference."),
-});
 const channelCreateSchema = z.strictObject({
     name: z.string().min(1).max(100).describe("Channel title."),
     description: z.string().min(1).max(500).optional().describe("Optional channel description."),
@@ -142,39 +133,26 @@ server.registerTool(
         }),
 );
 
-const childCreateSchema = z.strictObject({
-    name: z.string().min(1).max(100).describe("Child channel title."),
-    description: z
-        .string()
-        .min(1)
-        .max(500)
-        .optional()
-        .describe("Optional child channel description."),
-    agentModelId: z
-        .string()
-        .min(1)
-        .max(128)
-        .optional()
-        .describe("Optional available agent model ID for this child's independent session."),
-});
-
 server.registerTool(
     "channel_child_create",
     {
         title: "Create a child channel",
         description:
-            "Creates a private child channel under the current top-level channel. The child inherits the parent members and workspace while keeping an independent conversation and agent session.",
+            "Creates a private child channel under the current top-level channel. The child inherits the parent members and workspace while keeping an independent conversation and agent session. It can post an initial message; an agents message starts the child agent, while a people message only shares context.",
         inputSchema: childCreateSchema,
     },
     (input, extra) =>
         safeTool(async () => {
             const chat = requireChat(happyCallContext(extra));
-            const result = await callHost<{ chat: JsonObject }>(
+            const result = await callHost<{ chat: JsonObject; initialMessage?: JsonObject }>(
                 "/channels/createChildChannel",
                 chat.token,
                 input,
             );
-            return success(`Created child channel ${String(result.chat.id)}.`, result);
+            return success(
+                `Created child channel ${String(result.chat.id)}${result.initialMessage ? " and posted its initial message" : ""}.`,
+                result,
+            );
         }),
 );
 
@@ -274,4 +252,4 @@ async function safeTool(work: () => Promise<CallToolResult>): Promise<CallToolRe
     }
 }
 
-await startPluginServer(server);
+if (process.env.NODE_ENV !== "test") await startPluginServer(server);

--- a/packages/happy2-server/sources/modules/chat/channelDeleteFailedChildSetup.ts
+++ b/packages/happy2-server/sources/modules/chat/channelDeleteFailedChildSetup.ts
@@ -1,0 +1,69 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { type DrizzleExecutor, withTransaction } from "../drizzle.js";
+import { agentRigBindings, chatMembers, chats } from "../schema.js";
+import { syncSequenceNext } from "../sync/syncSequenceNext.js";
+import { chatAdvanceWithSequence } from "./chatAdvanceWithSequence.js";
+import { CollaborationError, type MutationHint } from "./types.js";
+
+/**
+ * Compensates a failed plugin child-channel setup by soft-deleting its chats row only when it is the same actor's newly created, empty child.
+ * It advances chatUpdates and removes child agentRigBindings so members reconcile the rollback without retaining a usable agent session; this supports admins without granting general deletion authority.
+ */
+export async function channelDeleteFailedChildSetup(
+    executor: DrizzleExecutor,
+    input: { actorUserId: string; chatId: string },
+): Promise<{ hint: MutationHint; memberUserIds: string[] }> {
+    return withTransaction(executor, async (tx) => {
+        const [child] = await tx
+            .select({
+                createdByUserId: chats.createdByUserId,
+                lastMessageSequence: chats.lastMessageSequence,
+                parentChatId: chats.parentChatId,
+            })
+            .from(chats)
+            .where(and(eq(chats.id, input.chatId), isNull(chats.deletedAt)))
+            .limit(1);
+        if (
+            !child ||
+            !child.parentChatId ||
+            child.createdByUserId !== input.actorUserId ||
+            child.lastMessageSequence !== 0
+        )
+            throw new CollaborationError(
+                "conflict",
+                "Failed child-channel setup can no longer be compensated",
+            );
+        const members = await tx
+            .select({ userId: chatMembers.userId })
+            .from(chatMembers)
+            .where(and(eq(chatMembers.chatId, input.chatId), isNull(chatMembers.leftAt)));
+        const sequence = await syncSequenceNext(tx);
+        const mutation = await chatAdvanceWithSequence(
+            tx,
+            sequence,
+            input.actorUserId,
+            input.chatId,
+            "chat.deleted",
+            input.chatId,
+        );
+        await tx
+            .update(chats)
+            .set({
+                deletedAt: sql`CURRENT_TIMESTAMP`,
+                deletedByUserId: input.actorUserId,
+                deleteReason: "Child channel initial message setup failed",
+                lifecycleVersion: sql`${chats.lifecycleVersion} + 1`,
+                updatedAt: sql`CURRENT_TIMESTAMP`,
+            })
+            .where(eq(chats.id, input.chatId));
+        await tx.delete(agentRigBindings).where(eq(agentRigBindings.chatId, input.chatId));
+        return {
+            hint: {
+                sequence: String(sequence),
+                chats: [{ chatId: mutation.chatId, pts: String(mutation.pts) }],
+                areas: [],
+            },
+            memberUserIds: [...new Set(members.map(({ userId }) => userId))],
+        };
+    });
+}

--- a/packages/happy2-server/sources/modules/plugin/impl/apiPermissions.ts
+++ b/packages/happy2-server/sources/modules/plugin/impl/apiPermissions.ts
@@ -17,7 +17,7 @@ const definitions = {
         id: "channels:create-child",
         displayName: "Create child channels",
         description:
-            "Create a private child channel under the current channel with inherited access and an independent agent session.",
+            "Create a private child channel under the current channel with inherited access and an independent agent session. Posting an initial message also requires Send messages permission.",
         section: "channels",
         access: "mutations",
     },

--- a/packages/happy2-server/sources/modules/plugin/service.ts
+++ b/packages/happy2-server/sources/modules/plugin/service.ts
@@ -19,6 +19,7 @@ import { documentWriteRequestCreate } from "../document/documentWriteRequestCrea
 import type { DocumentHostSummary, DocumentSnapshot } from "../document/types.js";
 import { chatUpdateMetadata, type ChatMetadataSummary } from "../chat/chatUpdateMetadata.js";
 import { channelCreateChild } from "../chat/channelCreateChild.js";
+import { channelDeleteFailedChildSetup } from "../chat/channelDeleteFailedChildSetup.js";
 import { channelCreateWithMembers } from "../chat/channelCreateWithMembers.js";
 import { channelMembersUpdate } from "../chat/channelMembersUpdate.js";
 import { channelSetArchived } from "../chat/channelSetArchived.js";
@@ -2596,14 +2597,21 @@ export class PluginService {
             name: string;
             description?: string;
             agentModelId?: string;
+            initialMessage?: { audience: "agents" | "people"; text: string };
         },
         agents?: PluginAgentRuntime,
     ) {
-        const claims = await this.authorizeChat(runtimeToken, chatToken, "channels:create-child");
-        if (input.agentModelId) {
+        const claims = await this.authorizeChat(
+            runtimeToken,
+            chatToken,
+            input.initialMessage
+                ? ["channels:create-child", "messages:send"]
+                : "channels:create-child",
+        );
+        if (input.agentModelId || input.initialMessage?.audience === "agents") {
             if (!agents)
                 throw new PluginError("not_ready", "AI agents are not enabled on this server");
-            await agents.modelRequireAvailable(input.agentModelId);
+            if (input.agentModelId) await agents.modelRequireAvailable(input.agentModelId);
         }
         const created = await channelCreateChild(this.executor, {
             actorUserId: claims.actorUserId,
@@ -2613,7 +2621,38 @@ export class PluginService {
             topic: input.description,
             agentModelId: input.agentModelId,
         });
-        await this.publishHints([created.hint], created.memberUserIds);
+        const hints = [created.hint];
+        let initialMessage;
+        try {
+            if (input.initialMessage) {
+                const agentTurns =
+                    input.initialMessage.audience === "agents"
+                        ? await agents!.prepareTurns({
+                              actorUserId: claims.actorUserId,
+                              agentUserIds: [],
+                              chatId: created.chat.id,
+                          })
+                        : [];
+                const sent = await messageSend(this.executor, {
+                    actorUserId: claims.actorUserId,
+                    chatId: created.chat.id,
+                    text: input.initialMessage.text,
+                    audience: input.initialMessage.audience,
+                    agentTurns,
+                });
+                initialMessage = sent.message;
+                hints.push(sent.hint);
+                if (agentTurns.length) agents!.startTurn(created.chat.id);
+            }
+        } catch (error) {
+            const deleted = await channelDeleteFailedChildSetup(this.executor, {
+                actorUserId: claims.actorUserId,
+                chatId: created.chat.id,
+            });
+            await this.publishHints([created.hint, deleted.hint], deleted.memberUserIds);
+            throw error;
+        }
+        await this.publishHints(hints, created.memberUserIds);
         return {
             chat: created.chat,
             token: await this.tokens.issuePluginChatToken({
@@ -2622,7 +2661,8 @@ export class PluginService {
                 actorUserId: claims.actorUserId,
                 agentUserId: claims.agentUserId,
             }),
-            sync: created.hint,
+            ...(initialMessage ? { initialMessage } : {}),
+            sync: input.initialMessage ? hints : created.hint,
         };
     }
 

--- a/packages/happy2-server/sources/routes/pluginHost.ts
+++ b/packages/happy2-server/sources/routes/pluginHost.ts
@@ -1201,9 +1201,10 @@ function childChannelCreateInput(value: unknown): {
     name: string;
     description?: string;
     agentModelId?: string;
+    initialMessage?: { audience: "agents" | "people"; text: string };
 } {
     const body = bodyRecord(value);
-    onlyBodyKeys(body, ["name", "description", "agentModelId"]);
+    onlyBodyKeys(body, ["name", "description", "agentModelId", "initialMessage"]);
     const name = requiredTrimmedString(body.name, "name", 100);
     const description =
         body.description === undefined
@@ -1211,10 +1212,22 @@ function childChannelCreateInput(value: unknown): {
             : requiredTrimmedString(body.description, "description", 500);
     const agentModelId =
         body.agentModelId === undefined ? undefined : identifier(body.agentModelId, "agentModelId");
+    let initialMessage: { audience: "agents" | "people"; text: string } | undefined;
+    if (body.initialMessage !== undefined) {
+        const message = bodyRecord(body.initialMessage, "initialMessage");
+        onlyBodyKeys(message, ["audience", "text"], "initialMessage");
+        if (message.audience !== "agents" && message.audience !== "people")
+            throw new PluginHostRequestError("initialMessage.audience must be agents or people");
+        initialMessage = {
+            audience: message.audience,
+            text: requiredMessageText(message.text),
+        };
+    }
     return {
         name,
         ...(description ? { description } : {}),
         ...(agentModelId ? { agentModelId } : {}),
+        ...(initialMessage ? { initialMessage } : {}),
     };
 }
 


### PR DESCRIPTION
## Summary
- add optional `initialMessage` to the real `channel_child_create` MCP schema and host parser
- post `people` context without inference and start the child agent for `agents` messages
- require/disclose message-send permission and preserve the legacy no-message response shape
- compensate failed child setup with narrow transactional chat/binding cleanup
- add real MCP schema/forwarding tests and focused gym coverage, including failed setup and exact-name retry

## Validation
- `pnpm format`
- `pnpm --dir packages/happy2-plugin-chat-management test` (4 passed)
- `pnpm --dir packages/happy2-plugin-chat-management typecheck`
- `pnpm --dir packages/happy2-plugin-chat-management lint`
- `pnpm --dir packages/happy2-server architecture:check`
- `pnpm --dir packages/happy2-server typecheck`
- focused gym test (2 passed)
- `pnpm --dir packages/happy2-gym lint` (0 errors; 1 pre-existing warning)
- dedicated GPT-5.6 Sol maximum-rigor review: no actionable in-scope findings remain