### PR TITLE
Add a compact copy button to every code block

### DIFF
--- a/packages/happy-desktop-ui/dev/pages/CodeBlockPage.tsx
+++ b/packages/happy-desktop-ui/dev/pages/CodeBlockPage.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react";
-import { CodeBlock, codeBlockLanguage } from "../../src/CodeBlock";
+import { CodeBlock, CodeBlockFrame, codeBlockLanguage } from "../../src/CodeBlock";
 import { ComponentPage, DimensionRule, Specimen } from "../kit";
 
 /** The component plan this page documents. The selector and the page header read the same value. */
@@ -42,7 +42,7 @@ export function CodeBlockPage() {
     return (
         <ComponentPage
             number={componentNumber}
-            summary="Code with syntax highlighting, wherever code is read: the source face of the file viewer and every fenced block in a document. Colors follow the surrounding theme through color-scheme, so there is no appearance prop to thread."
+            summary="Code with syntax highlighting, wherever code is read: the source face of the file viewer and every fenced block in a document. A Markdown frame adds one top-right copy action without covering the code or its scrollbar. Colors follow the surrounding theme through color-scheme, so there is no appearance prop to thread."
             title="CodeBlock"
         >
             <Specimen
@@ -63,7 +63,11 @@ export function CodeBlockPage() {
                 number="02"
                 stage="surface"
             >
-                {frame(<CodeBlock lang={codeBlockLanguage("bash")} text={shell} />)}
+                {frame(
+                    <CodeBlockFrame text={shell}>
+                        <CodeBlock lang={codeBlockLanguage("bash")} text={shell} />
+                    </CodeBlockFrame>,
+                )}
             </Specimen>
 
             <Specimen

--- a/packages/happy-desktop-ui/src/CodeBlock.tsx
+++ b/packages/happy-desktop-ui/src/CodeBlock.tsx
@@ -1,6 +1,7 @@
 import { EXTENSION_TO_FILE_FORMAT } from "@pierre/diffs";
 import { File } from "@pierre/diffs/react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { CopyButton } from "./CopyButton";
 import { PIERRE_PANE_CSS, pierreCodeSurfacePhase } from "./pierreCodeSurface";
 
 /** Do not retain Pierre ASTs for unusually large documents. */
@@ -59,6 +60,39 @@ export type CodeBlockProps = {
     /** Numbers the lines. On for a file, off for a snippet inside prose. */
     lineNumbers?: boolean;
 };
+
+export type CodeBlockFrameProps = {
+    readonly children: ReactNode;
+    readonly className?: string;
+    readonly "data-happy-desktop-ui"?: string;
+    readonly "data-testid"?: string;
+    readonly style?: CSSProperties;
+    /** Exact displayed code copied by the frame action. */
+    readonly text: string;
+};
+
+/**
+ * The shared Markdown code-block frame: a reserved action strip above any code
+ * renderer, with one quiet copy action that never covers code or its scrollbar.
+ */
+export function CodeBlockFrame(props: CodeBlockFrameProps) {
+    return (
+        <div
+            className={["happy-code-block-frame", props.className].filter(Boolean).join(" ")}
+            data-happy-desktop-ui={props["data-happy-desktop-ui"] ?? "code-block-frame"}
+            data-testid={props["data-testid"]}
+            style={props.style}
+        >
+            <CopyButton
+                className="happy-code-block-frame__copy"
+                data-happy-desktop-ui="code-block-copy"
+                label="Copy code"
+                text={props.text}
+            />
+            {props.children}
+        </div>
+    );
+}
 
 /**
  * C-174 CodeBlock — code with syntax highlighting, wherever code is read.

--- a/packages/happy-desktop-ui/src/MarkdownDocument.tsx
+++ b/packages/happy-desktop-ui/src/MarkdownDocument.tsx
@@ -10,8 +10,8 @@ import {
 } from "react";
 import Markdown, { type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { CodeBlock } from "./CodeBlock";
-import { markdownFence, markdownFenceIsMermaid } from "./markdownFence";
+import { CodeBlock, CodeBlockFrame } from "./CodeBlock";
+import { markdownCodeText, markdownFence, markdownFenceIsMermaid } from "./markdownFence";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { ScrollArea } from "./Scrollbar";
 
@@ -186,9 +186,10 @@ const DocumentPre = ({
     if (markdownFenceIsMermaid(fence))
         return <MermaidDiagram source={fence!.text} variant="document" />;
     return (
-        <div
+        <CodeBlockFrame
             className="happy-markdown-document__code"
             data-happy-desktop-ui="markdown-document-code"
+            text={fence?.text ?? markdownCodeText(node) ?? ""}
         >
             {fence ? (
                 <CodeBlock
@@ -205,7 +206,7 @@ const DocumentPre = ({
                     <pre {...props}>{children}</pre>
                 </ScrollArea>
             )}
-        </div>
+        </CodeBlockFrame>
     );
 };
 

--- a/packages/happy-desktop-ui/src/MessageMarkdown.tsx
+++ b/packages/happy-desktop-ui/src/MessageMarkdown.tsx
@@ -8,8 +8,9 @@ import {
     type ReactNode,
 } from "react";
 import Markdown, { type Components, type ExtraProps } from "react-markdown";
+import { CodeBlockFrame } from "./CodeBlock";
 import { filePreviewKind } from "./FilePreview";
-import { markdownFence, markdownFenceIsMermaid } from "./markdownFence";
+import { markdownCodeText, markdownFence, markdownFenceIsMermaid } from "./markdownFence";
 import { markdownDocumentLinkPath } from "./MarkdownDocument";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { MESSAGE_MARKDOWN_REMARK_PLUGINS } from "./messageMarkdownAst";
@@ -207,15 +208,20 @@ const MarkdownPre = ({
             />
         );
     return (
-        <ScrollArea
-            axes="horizontal"
+        <CodeBlockFrame
             className="happy-message__code-block"
             data-happy-desktop-ui="message-code-block"
-            placement="overlay"
-            viewportClassName="happy-message__code-block-viewport"
+            text={fence?.text ?? markdownCodeText(node) ?? ""}
         >
-            <pre {...props}>{children}</pre>
-        </ScrollArea>
+            <ScrollArea
+                axes="horizontal"
+                data-happy-desktop-ui="message-code-scroll"
+                placement="overlay"
+                viewportClassName="happy-message__code-block-viewport"
+            >
+                <pre {...props}>{children}</pre>
+            </ScrollArea>
+        </CodeBlockFrame>
     );
 };
 const MarkdownTable = ({

--- a/packages/happy-desktop-ui/src/index.ts
+++ b/packages/happy-desktop-ui/src/index.ts
@@ -4,7 +4,13 @@ export { happyLogoBlackUrl, happyLogoWhiteUrl } from "./assets";
 export { ChangedFileDiff, type ChangedFileDiffProps } from "./ChangedFileDiff";
 export { CompactActivityRow, type CompactActivityRowProps } from "./CompactActivityRow";
 export { compactCount } from "./countText";
-export { CodeBlock, codeBlockLanguage, type CodeBlockProps } from "./CodeBlock";
+export {
+    CodeBlock,
+    CodeBlockFrame,
+    codeBlockLanguage,
+    type CodeBlockFrameProps,
+    type CodeBlockProps,
+} from "./CodeBlock";
 export { CodeEditor, type CodeEditorProps } from "./CodeEditor";
 export {
     ScrollArea,

--- a/packages/happy-desktop-ui/src/markdownFence.ts
+++ b/packages/happy-desktop-ui/src/markdownFence.ts
@@ -8,17 +8,26 @@ export type MarkdownFence = {
     readonly text: string;
 };
 
+/** Code text emitted by the Markdown parser, without its synthetic final newline. */
+export function markdownCodeText(node: ExtraProps["node"]): string | undefined {
+    const code = node?.children.find(
+        (child) => child.type === "element" && child.tagName === "code",
+    );
+    if (code === undefined || code.type !== "element") return undefined;
+    return code.children
+        .map((child) => (child.type === "text" ? child.value : ""))
+        .join("")
+        .replace(/\n$/u, "");
+}
+
 /** The authored contents and info label of one fenced Markdown code block. */
 export function markdownFence(node: ExtraProps["node"]): MarkdownFence | undefined {
     const code = node?.children.find(
         (child) => child.type === "element" && child.tagName === "code",
     );
     if (code === undefined || code.type !== "element") return undefined;
-    const text = code.children
-        .map((child) => (child.type === "text" ? child.value : ""))
-        .join("")
-        .replace(/\n$/u, "");
-    if (text.length === 0) return undefined;
+    const text = markdownCodeText(node);
+    if (text === undefined || text.length === 0) return undefined;
     const names = code.properties["className"];
     const label = (Array.isArray(names) ? names.map(String) : [])
         .find((name) => name.startsWith("language-"))

--- a/packages/happy-desktop-ui/src/styles/code-block.css
+++ b/packages/happy-desktop-ui/src/styles/code-block.css
@@ -8,6 +8,32 @@
  * `color-scheme`, which the theme sets and the shadow tree inherits.
  */
 
+.happy-code-block-frame {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    max-width: 100%;
+    padding-top: 28px;
+    overflow: hidden;
+    border-radius: var(--happy-radius-sm);
+    background: var(--surface-pressed);
+}
+
+.happy-code-block-frame__copy {
+    /* The copy control overlays only the frame's reserved top strip, outside
+       the code and scrollbar flow. */
+    position: absolute;
+    z-index: 1;
+    top: 4px;
+    right: 8px;
+    opacity: 1;
+}
+
+.happy-code-block-frame__copy:hover {
+    background: var(--surface-selected);
+}
+
 .happy-code-block {
     display: block;
     min-width: 0;

--- a/packages/happy-desktop-ui/src/styles/message.css
+++ b/packages/happy-desktop-ui/src/styles/message.css
@@ -772,8 +772,12 @@
 .happy-message__code-block {
     margin: 12px 0;
     max-width: 100%;
+}
+
+/* Chat code is a content card at the existing 8px radius; the shared frame's
+   smaller document/control default must not change that established geometry. */
+.happy-message__code-block.happy-code-block-frame {
     border-radius: 8px;
-    background: var(--surface-pressed);
 }
 
 .happy-message__code-block-viewport {


### PR DESCRIPTION
## Summary

- add a shared code-block frame with a compact top-right copy action and inline success feedback
- use the same treatment for conversation Markdown and rendered document/file-preview Markdown while leaving Mermaid diagrams unchanged
- copy the exact code contents without Markdown fences, language labels, or parser-added trailing newlines

## Verification

- `pnpm --filter happy-desktop-ui format:check`
- `pnpm --filter happy-desktop-ui lint`
- `pnpm --filter happy-desktop-ui typecheck`
- `pnpm --filter happy-desktop-ui build`
- Blueprint in Chrome at 2x: verified chat/document layout, exact clipboard contents, keyboard focus, success feedback, and no overlap with code or scrollbars

Closes #10