### PR TITLE
Add file and folder context-menu actions

### DIFF
--- a/packages/happy-desktop-app/sources/AppHappyAgentView.tsx
+++ b/packages/happy-desktop-app/sources/AppHappyAgentView.tsx
@@ -28,6 +28,7 @@ import type {
     HappyAgentModelStore,
     HappyAgentModelSelection,
     HappyAgentNavigationOrderStore,
+    HappyAgentOpenInTarget,
     HappyAgentSidebarCollapseStore,
     HappyAgentPanelSnapshot,
     HappyAgentProjectAddSnapshot,
@@ -114,6 +115,7 @@ import {
     FilePreview,
     FormRow,
     type FilePreviewKind,
+    type ContextMenuSelectionResult,
     filePreviewKind,
     Lightbox,
     MarkdownDocument,
@@ -129,6 +131,7 @@ import {
     fileNameCompare,
     type FileTreeExpansion,
     type FileTreeBuildEntry,
+    type FileTreeContextSelection,
     HappyAgentCreateSessionPage,
     HappySocialPage,
     HappyAgentProjectCloneDialog,
@@ -521,6 +524,8 @@ interface OpenGroup {
     readonly lifecycle?: HappyAgentGroupLifecycle;
     /** The checkout's path, so a notice about it can name the directory. */
     readonly path: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    readonly hostPath?: string;
 }
 
 const PANEL_TOGGLE_HINT = {
@@ -920,8 +925,142 @@ const TAB_MENU_CLOSE_OTHERS = "close-others";
 const TAB_MENU_CLOSE_LEFT = "close-left";
 const TAB_MENU_CLOSE_RIGHT = "close-right";
 const TAB_MENU_CLOSE_ALL = "close-all";
+const FILE_MENU_OPEN = "file-open";
+const FILE_MENU_REVEAL = "file-reveal";
+const FILE_MENU_COPY_PATH = "file-copy-path";
+const FILE_MENU_COPY_RELATIVE_PATH = "file-copy-relative-path";
+const FILE_MENU_OPEN_IN_PREFIX = "file-open-in:";
 const fileDocumentIdentities = new WeakMap<object, number>();
 let fileDocumentIdentityNext = 0;
+
+interface FileContextTarget {
+    readonly kind: "directory" | "file";
+    readonly path: string;
+    /** The change list says this item no longer exists in the working tree. */
+    readonly missing?: boolean;
+}
+
+interface FileContextMenuOptions {
+    readonly canonicalRoot?: string;
+    readonly includeOpen: boolean;
+    readonly nativeActions: boolean;
+    readonly openInTargets: readonly HappyAgentOpenInTarget[];
+    readonly unavailableReason?: string;
+}
+
+function fileContextTargets(selection: FileTreeContextSelection): readonly FileContextTarget[] {
+    return selection.entries.map((entry) => ({
+        kind: entry.kind,
+        path: entry.id,
+        ...(entry.gitStatus === "deleted" ? { missing: true } : {}),
+    }));
+}
+
+function fileContextAction(actionId: string): boolean {
+    return (
+        actionId === FILE_MENU_OPEN ||
+        actionId === FILE_MENU_REVEAL ||
+        actionId === FILE_MENU_COPY_PATH ||
+        actionId === FILE_MENU_COPY_RELATIVE_PATH ||
+        actionId.startsWith(FILE_MENU_OPEN_IN_PREFIX)
+    );
+}
+
+/** Joins a daemon-canonical root while preserving the separator that root uses. */
+function workspaceItemPath(root: string, relativePath: string): string {
+    const windowsRoot = /^[A-Za-z]:[\\/]/u.test(root) || root.startsWith("\\\\");
+    const base = windowsRoot ? root.replace(/[\\/]+$/u, "") : root.replace(/\/+$/u, "");
+    const path = windowsRoot
+        ? relativePath.replace(/^[\\/]+/u, "").replaceAll("/", "\\")
+        : relativePath.replace(/^\/+/u, "");
+    if (path.length === 0) return root;
+    const separator = windowsRoot ? "\\" : "/";
+    return `${base}${separator}${path}`;
+}
+
+function fileContextMenuItems(
+    targets: readonly FileContextTarget[],
+    options: FileContextMenuOptions,
+): MenuItem[] {
+    if (targets.length === 0) return [];
+    const multiple = targets.length > 1;
+    const allFiles = targets.every((target) => target.kind === "file");
+    const missing = targets.some((target) => target.missing === true);
+    const nativeRefusal =
+        options.unavailableReason ??
+        (missing
+            ? multiple
+                ? "A selected item no longer exists in the workspace."
+                : "This item no longer exists in the workspace."
+            : undefined);
+    const open: MenuItem[] =
+        options.includeOpen && allFiles
+            ? [
+                  {
+                      kind: "item",
+                      id: FILE_MENU_OPEN,
+                      label: multiple ? `Open ${String(targets.length)} files` : "Open",
+                      icon: "doc",
+                      disabled: nativeRefusal !== undefined,
+                      ...(nativeRefusal ? { disabledReason: nativeRefusal } : {}),
+                  },
+              ]
+            : [];
+    const native: MenuItem[] = options.nativeActions
+        ? [
+              {
+                  kind: "item",
+                  id: FILE_MENU_REVEAL,
+                  label: multiple
+                      ? `Show ${String(targets.length)} items in Finder`
+                      : "Show in Finder",
+                  icon: "eye",
+                  disabled: nativeRefusal !== undefined,
+                  ...(nativeRefusal ? { disabledReason: nativeRefusal } : {}),
+              },
+              ...options.openInTargets
+                  .filter((target) => target.id !== "finder")
+                  .map(
+                      (target): MenuItem => ({
+                          kind: "item",
+                          id: `${FILE_MENU_OPEN_IN_PREFIX}${target.id}`,
+                          label: multiple
+                              ? `Open ${String(targets.length)} items in ${target.label}`
+                              : `Open in ${target.label}`,
+                          ...(target.iconUrl ? { iconUrl: target.iconUrl } : {}),
+                          disabled: nativeRefusal !== undefined,
+                          ...(nativeRefusal ? { disabledReason: nativeRefusal } : {}),
+                      }),
+                  ),
+          ]
+        : [];
+    const copy: MenuItem[] = [
+        ...(options.canonicalRoot
+            ? [
+                  {
+                      kind: "item" as const,
+                      id: FILE_MENU_COPY_PATH,
+                      label: multiple ? "Copy paths" : "Copy path",
+                      icon: "copy" as const,
+                  },
+              ]
+            : []),
+        {
+            kind: "item",
+            id: FILE_MENU_COPY_RELATIVE_PATH,
+            label: multiple ? "Copy relative paths" : "Copy relative path",
+            icon: "copy",
+        },
+    ];
+    const actions = [...open, ...native];
+    return actions.length === 0 ? copy : [...actions, { kind: "separator" }, ...copy];
+}
+
+function clipboardWrite(text: string, feedback: string): Promise<ContextMenuSelectionResult> {
+    if (!navigator.clipboard)
+        return Promise.reject(new Error("Clipboard access is unavailable in this window."));
+    return navigator.clipboard.writeText(text).then(() => ({ feedback }));
+}
 
 /**
  * The context menu one tab offers: the usual sweeps — this tab, the others,
@@ -1116,6 +1255,7 @@ function openGroupFind(
             // one, and `sessionCreateAvailable` is what withholds that control.
             create: { cwd: bot.path, worktreeId: bot.workspaceId },
             path: bot.displayPath,
+            ...(bot.hostPath === undefined ? {} : { hostPath: bot.hostPath }),
         };
     for (const project of projects) {
         if (project.id === groupId)
@@ -1128,6 +1268,7 @@ function openGroupFind(
                 create: { cwd: project.path },
                 lifecycle: project.lifecycle,
                 path: project.displayPath,
+                ...(project.hostPath === undefined ? {} : { hostPath: project.hostPath }),
             };
         for (const worktree of project.worktrees)
             if (worktree.id === groupId)
@@ -1140,6 +1281,7 @@ function openGroupFind(
                     create: { cwd: worktree.path, worktreeId: worktree.id },
                     lifecycle: worktree.lifecycle,
                     path: worktree.displayPath,
+                    ...(worktree.hostPath === undefined ? {} : { hostPath: worktree.hostPath }),
                 };
     }
     return undefined;
@@ -2962,6 +3104,74 @@ function HappyAgentWorkspaceSurface(props: HappyAgentWorkspaceSurfaceProps) {
     const activeMainTool = mainTools.find((tab) => tab.id === workspace.activeMainViewId);
     const displayedMainTool = mainTools.find((tab) => tab.id === workspace.displayedMainViewId);
     const openInRecent = workspace.openInRecent;
+    const pathUnavailableReason =
+        connectionRefusal ??
+        (openGroupPhase === "creating"
+            ? "This workspace is still being created."
+            : openGroupPhase === "missing"
+              ? "This workspace is missing from its machine."
+              : openGroupPhase === "failed"
+                ? "This workspace could not be created."
+                : undefined);
+    const fileTarget = (path: string): FileContextTarget => ({
+        kind: "file",
+        path,
+        ...(openGroup?.changes.some(
+            (change) => change.path === path && change.status === "deleted",
+        ) === true
+            ? { missing: true }
+            : {}),
+    });
+    const fileMenuItems = (
+        targets: readonly FileContextTarget[],
+        includeOpen: boolean,
+    ): MenuItem[] =>
+        fileContextMenuItems(targets, {
+            ...(openGroup?.hostPath ? { canonicalRoot: openGroup.hostPath } : {}),
+            includeOpen,
+            nativeActions: workspace.nativeWorkspaceActions && openGroup?.hostPath !== undefined,
+            openInTargets: workspace.openInTargets,
+            ...(pathUnavailableReason ? { unavailableReason: pathUnavailableReason } : {}),
+        });
+    const fileMenuSelect = (
+        targets: readonly FileContextTarget[],
+        actionId: string,
+    ): ContextMenuSelectionResult | Promise<ContextMenuSelectionResult> => {
+        const group = openGroup;
+        if (!group || targets.length === 0) return;
+        const paths = targets.map((target) => target.path);
+        if (actionId === FILE_MENU_COPY_RELATIVE_PATH)
+            return clipboardWrite(
+                paths.join("\n"),
+                paths.length === 1 ? "Relative path copied" : "Relative paths copied",
+            );
+        if (actionId === FILE_MENU_COPY_PATH) {
+            const root = group.hostPath;
+            if (!root) return;
+            return clipboardWrite(
+                paths.map((path) => workspaceItemPath(root, path)).join("\n"),
+                paths.length === 1 ? "Path copied" : "Paths copied",
+            );
+        }
+        if (!happyAgentOnline())
+            return Promise.reject(new Error(connectionRefusal ?? "Happy Agent is unavailable."));
+        if (actionId === FILE_MENU_OPEN) {
+            for (const target of targets) {
+                if (target.kind !== "file") continue;
+                const kind = fileTabKind(target.path);
+                props.workspace.fileOpen(group.id, target.path, kind);
+                props.onFileSelect(group.id, props.chatId, target.path, kind);
+            }
+            return;
+        }
+        if (actionId === FILE_MENU_REVEAL)
+            return props.workspace.workspacePathsReveal(group.id, paths);
+        if (actionId.startsWith(FILE_MENU_OPEN_IN_PREFIX)) {
+            const targetId = actionId.slice(FILE_MENU_OPEN_IN_PREFIX.length);
+            const target = workspace.openInTargets.find((candidate) => candidate.id === targetId);
+            if (target) return props.workspace.workspacePathsOpenIn(group.id, paths, target);
+        }
+    };
     const conversation = workspace.conversation;
     // A chat that belongs to another session rather than to this group's strip.
     // The state says so outright — the host gives such a session no place in an
@@ -3319,6 +3529,8 @@ function HappyAgentWorkspaceSurface(props: HappyAgentWorkspaceSurfaceProps) {
                         mediaWindow={props.mediaWindow}
                         sessionId={props.chatId}
                         changes={openGroup?.changes ?? []}
+                        fileMenuItems={fileMenuItems}
+                        onFileMenuSelect={fileMenuSelect}
                         expanded={workspace.fileTreeExpanded}
                         collapsed={workspace.fileTreeCollapsed}
                         layout={workspace.fileLayout}
@@ -3782,9 +3994,22 @@ function HappyAgentWorkspaceSurface(props: HappyAgentWorkspaceSurfaceProps) {
                                     mainTools.some((entry) => entry.id === tab.id)
                                         ? "Close"
                                         : "Archive";
-                                return tabStripMenu(verb, index, sweepableTabs.length - index - 1);
+                                const strip = tabStripMenu(
+                                    verb,
+                                    index,
+                                    sweepableTabs.length - index - 1,
+                                );
+                                const file = groupFileTabs.find((entry) => entry.id === tab.id);
+                                if (!file) return strip;
+                                const path = fileMenuItems([fileTarget(file.path)], false);
+                                return path.length === 0
+                                    ? strip
+                                    : [...path, { kind: "separator" }, ...strip];
                             }}
                             onTabMenuSelect={(tab, actionId) => {
+                                const file = groupFileTabs.find((entry) => entry.id === tab.id);
+                                if (file && fileContextAction(actionId))
+                                    return fileMenuSelect([fileTarget(file.path)], actionId);
                                 const ids = sweepableTabs.map((entry) => entry.id);
                                 const index = ids.indexOf(tab.id);
                                 if (index < 0) return;
@@ -5326,6 +5551,14 @@ function HappyAgentPanelBody(props: {
     mediaWindow?: MediaWindowOpener;
     canStartTerminal: boolean;
     changes: OpenGroup["changes"];
+    fileMenuItems: (
+        targets: readonly FileContextTarget[],
+        includeOpen: boolean,
+    ) => readonly MenuItem[];
+    onFileMenuSelect: (
+        targets: readonly FileContextTarget[],
+        actionId: string,
+    ) => ContextMenuSelectionResult | Promise<ContextMenuSelectionResult>;
     closeShortcut?: KeyboardShortcut;
     expanded: ReadonlySet<string>;
     collapsed: ReadonlySet<string>;
@@ -5412,6 +5645,17 @@ function HappyAgentPanelBody(props: {
     const panelTools = toolTabsPlaced(props.panel, "panel");
     const activeToolTab = panelTools.find((tab) => tab.id === props.panel.activeViewId);
     const panelFile = props.panelFile;
+    const panelFileTarget: FileContextTarget | undefined = panelFile
+        ? {
+              kind: "file",
+              path: panelFile.path,
+              ...(props.changes.some(
+                  (change) => change.path === panelFile.path && change.status === "deleted",
+              )
+                  ? { missing: true }
+                  : {}),
+          }
+        : undefined;
     const activityTabShown =
         props.panel.activityViewOpen ||
         (props.activity?.activityAvailable === true && !props.panel.activityViewDismissed);
@@ -5533,6 +5777,20 @@ function HappyAgentPanelBody(props: {
                             props.store.fileViewOpen();
                         else props.store.tabSelect(tabId as HappyAgentPanelTabId);
                     }}
+                    tabMenuItems={(tab) => {
+                        if (tab.id !== HAPPY_AGENT_PANEL_FILE_VIEW_ID || !panelFileTarget)
+                            return [];
+                        return [
+                            ...props.fileMenuItems([panelFileTarget], false),
+                            { kind: "separator" },
+                            { kind: "item", id: TAB_MENU_CLOSE, label: "Close tab" },
+                        ];
+                    }}
+                    onTabMenuSelect={(tab, actionId) => {
+                        if (panelFileTarget && fileContextAction(actionId))
+                            return props.onFileMenuSelect([panelFileTarget], actionId);
+                        if (actionId === TAB_MENU_CLOSE) props.onViewClose(tab.id);
+                    }}
                     onTransfer={(tabId) => props.onViewTransfer(tabId)}
                     tabs={tabs}
                     // The listing opens content rather than being content, and a
@@ -5574,6 +5832,12 @@ function HappyAgentPanelBody(props: {
                             layout={props.layout}
                             loading={loading}
                             nodes={nodes}
+                            rowMenuItems={(selection) =>
+                                props.fileMenuItems(fileContextTargets(selection), true)
+                            }
+                            onRowMenuSelect={(selection, actionId) =>
+                                props.onFileMenuSelect(fileContextTargets(selection), actionId)
+                            }
                             {...(props.happyAgentAvailability !== undefined && all
                                 ? {
                                       fileActionsUnavailable:

--- a/packages/happy-desktop-electron/sources/main/browserDevServer.ts
+++ b/packages/happy-desktop-electron/sources/main/browserDevServer.ts
@@ -124,6 +124,7 @@ export function browserLocalHappyAgentPlugin(options: BrowserLocalHappyAgentOpti
                         const handled = await happyAgentProxyHandle({
                             client: active.connection.client,
                             method: request.method ?? "GET",
+                            nativeWorkspaceOwner: true,
                             path: bridgePath,
                             query: url.searchParams,
                             request,

--- a/packages/happy-desktop-electron/sources/main/happyAgentHttpProxy.ts
+++ b/packages/happy-desktop-electron/sources/main/happyAgentHttpProxy.ts
@@ -164,6 +164,7 @@ export function happyAgentHttpProxyCreate(
         void happyAgentProxyHandle({
             client,
             method: request.method ?? "GET",
+            nativeWorkspaceOwner: true,
             path: requestPath,
             query: url.searchParams,
             request,

--- a/packages/happy-desktop-electron/sources/main/happyAgentProxyHandle.test.ts
+++ b/packages/happy-desktop-electron/sources/main/happyAgentProxyHandle.test.ts
@@ -1,0 +1,125 @@
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import {
+    happyAgentProxyHandle,
+    workspaceNativePathResolve,
+    type HappyAgentProxyClient,
+} from "./happyAgentProxyHandle";
+
+interface CapturedResponse {
+    readonly response: ServerResponse;
+    body: string;
+    status?: number;
+}
+
+function responseCapture(): CapturedResponse {
+    const captured: CapturedResponse = {
+        body: "",
+        response: undefined as unknown as ServerResponse,
+    };
+    let headersSent = false;
+    const response = {
+        get headersSent() {
+            return headersSent;
+        },
+        writeHead(status: number) {
+            captured.status = status;
+            headersSent = true;
+            return response;
+        },
+        end(chunk?: string) {
+            if (chunk) captured.body = chunk;
+            return response;
+        },
+    } as unknown as ServerResponse;
+    Object.assign(captured, { response });
+    return captured;
+}
+
+function jsonRequest(body: unknown): IncomingMessage {
+    return Readable.from([JSON.stringify(body)]) as unknown as IncomingMessage;
+}
+
+describe("workspace native paths", () => {
+    it("resolves only paths inside the daemon-authoritative workspace root", () => {
+        expect(workspaceNativePathResolve("/projects/happy", "src/../README.md")).toBe(
+            "/projects/happy/README.md",
+        );
+        expect(() => workspaceNativePathResolve("/projects/happy", "../secret.txt")).toThrow(
+            "cannot leave its workspace",
+        );
+        expect(() => workspaceNativePathResolve("/projects/happy", "/etc/passwd")).toThrow(
+            "must be relative",
+        );
+    });
+
+    it("refuses a native action when the workspace belongs to another machine", async () => {
+        const getWorkspace = vi.fn();
+        const client = { getWorkspace } as unknown as HappyAgentProxyClient;
+        const captured = responseCapture();
+
+        await happyAgentProxyHandle({
+            client,
+            method: "POST",
+            nativeWorkspaceOwner: false,
+            path: "/workspace-paths-reveal",
+            query: new URLSearchParams(),
+            request: jsonRequest({ workspaceId: "workspace-1", paths: ["README.md"] }),
+            response: captured.response,
+        });
+
+        expect(captured.status).toBe(502);
+        expect(JSON.parse(captured.body)).toEqual({
+            error: "This workspace belongs to another machine.",
+        });
+        expect(getWorkspace).not.toHaveBeenCalled();
+    });
+
+    it("rejects a route path outside the daemon-authoritative workspace root", async () => {
+        const getWorkspace = vi.fn().mockResolvedValue({
+            workspace: { compute: { type: "host", path: "/projects/happy" } },
+        });
+        const client = { getWorkspace } as unknown as HappyAgentProxyClient;
+        const captured = responseCapture();
+
+        await happyAgentProxyHandle({
+            client,
+            method: "POST",
+            nativeWorkspaceOwner: true,
+            path: "/workspace-paths-reveal",
+            query: new URLSearchParams(),
+            request: jsonRequest({ workspaceId: "workspace-1", paths: ["../secret.txt"] }),
+            response: captured.response,
+        });
+
+        expect(captured.status).toBe(502);
+        expect(JSON.parse(captured.body)).toEqual({
+            error: "A workspace item path cannot leave its workspace.",
+        });
+        expect(getWorkspace).toHaveBeenCalledWith("workspace-1");
+    });
+
+    it("does not hand Docker workspace paths to the desktop host", async () => {
+        const getWorkspace = vi.fn().mockResolvedValue({
+            workspace: { compute: { type: "docker", image: "node:24" } },
+        });
+        const client = { getWorkspace } as unknown as HappyAgentProxyClient;
+        const captured = responseCapture();
+
+        await happyAgentProxyHandle({
+            client,
+            method: "POST",
+            nativeWorkspaceOwner: true,
+            path: "/workspace-paths-reveal",
+            query: new URLSearchParams(),
+            request: jsonRequest({ workspaceId: "workspace-1", paths: ["README.md"] }),
+            response: captured.response,
+        });
+
+        expect(captured.status).toBe(502);
+        expect(JSON.parse(captured.body)).toEqual({
+            error: "A Docker workspace has no path the local desktop can open.",
+        });
+    });
+});

--- a/packages/happy-desktop-electron/sources/main/happyAgentProxyHandle.ts
+++ b/packages/happy-desktop-electron/sources/main/happyAgentProxyHandle.ts
@@ -1,5 +1,6 @@
 import { stat } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { HappyAgentApiError } from "@slopus/happy-agent-client";
 import {
@@ -7,7 +8,7 @@ import {
     HappyAgentDaemonHttpError,
     type HappyAgentDaemonClient,
 } from "./happyAgentDaemonClient";
-import { openInRun, openInTargetsRead } from "./openIn";
+import { openInRun, openInTargetsRead, revealInFileManager } from "./openIn";
 import { happyAgentDaemonHealthProject } from "./happyAgentHttpProxy";
 
 /** The minimal Happy Agent surface used by the loopback bridge. */
@@ -23,6 +24,12 @@ export interface HappyAgentProxyHandleOptions {
     readonly query: URLSearchParams;
     readonly request: IncomingMessage;
     readonly response: ServerResponse;
+    /**
+     * Whether this proxy's daemon owns workspaces on this exact desktop.
+     * Native actions are refused unless the caller states that ownership; a
+     * future peer proxy therefore cannot accidentally reveal its paths here.
+     */
+    readonly nativeWorkspaceOwner: boolean;
     readonly onConnectionError?: (error: unknown) => void;
     /** Publishes one workspace file as an isolated local preview site. */
     readonly htmlPreviewUrl?: (workspaceId: string, filePath: string) => string;
@@ -81,10 +88,31 @@ export async function happyAgentProxyHandle(
             const body = await bodyReadJson(request);
             const workspaceId = requiredString(body.workspaceId, "workspaceId");
             const target = requiredString(body.target, "target");
-            const { workspace } = await client.getWorkspace(workspaceId);
-            if (workspace.compute.type !== "host")
-                throw new Error("A container workspace cannot be opened as a local folder.");
-            await openInRun(target, workspace.compute.path);
+            const paths = optionalStringArray(body.paths, "paths");
+            await openInRun(
+                target,
+                await nativeWorkspacePaths(
+                    client,
+                    workspaceId,
+                    paths,
+                    options.nativeWorkspaceOwner,
+                ),
+            );
+            writeJson(response, 200, {});
+            return true;
+        }
+        if (method === "POST" && path === "/workspace-paths-reveal") {
+            const body = await bodyReadJson(request);
+            const workspaceId = requiredString(body.workspaceId, "workspaceId");
+            const paths = requiredStringArray(body.paths, "paths");
+            await revealInFileManager(
+                await nativeWorkspacePaths(
+                    client,
+                    workspaceId,
+                    paths,
+                    options.nativeWorkspaceOwner,
+                ),
+            );
             writeJson(response, 200, {});
             return true;
         }
@@ -189,6 +217,38 @@ function attachmentNameSafe(name: string): string {
         .filter((character) => (character.codePointAt(0) ?? 0) >= 0x20)
         .join("");
     return printable.replace(/^\.+/u, "").trim().slice(0, 120) || "attachment";
+}
+
+/** Maximum items one context-menu action may hand to the operating system. */
+const NATIVE_PATH_LIMIT = 64;
+
+export function workspaceNativePathResolve(root: string, path: string): string {
+    if (isAbsolute(path)) throw new Error("Workspace item paths must be relative.");
+    const target = resolve(root, path);
+    const within = relative(root, target);
+    if (within === ".." || within.startsWith(`..${sep}`) || isAbsolute(within))
+        throw new Error("A workspace item path cannot leave its workspace.");
+    return target;
+}
+
+/**
+ * Resolves renderer-supplied relative paths only after the daemon has named the
+ * checkout root, and only when that checkout belongs to this desktop.
+ */
+async function nativeWorkspacePaths(
+    client: HappyAgentProxyClient,
+    workspaceId: string,
+    paths: readonly string[] | undefined,
+    nativeWorkspaceOwner: boolean,
+): Promise<readonly string[]> {
+    if (!nativeWorkspaceOwner) throw new Error("This workspace belongs to another machine.");
+    const { workspace } = await client.getWorkspace(workspaceId);
+    if (workspace.compute.type !== "host")
+        throw new Error("A Docker workspace has no path the local desktop can open.");
+    const root = workspace.compute.path;
+    return paths === undefined
+        ? [root]
+        : paths.map((path) => workspaceNativePathResolve(root, path));
 }
 
 function attachmentNameNumbered(name: string, attempt: number): string {
@@ -513,6 +573,16 @@ function requiredString(value: unknown, name: string): string {
 function stringValue(value: unknown, name: string): string {
     if (typeof value !== "string") throw new Error(`${name} is required.`);
     return value;
+}
+
+function optionalStringArray(value: unknown, name: string): readonly string[] | undefined {
+    return value === undefined ? undefined : requiredStringArray(value, name);
+}
+
+function requiredStringArray(value: unknown, name: string): readonly string[] {
+    if (!Array.isArray(value) || value.length === 0 || value.length > NATIVE_PATH_LIMIT)
+        throw new Error(`${name} must contain between 1 and ${String(NATIVE_PATH_LIMIT)} paths.`);
+    return value.map((entry, index) => stringValue(entry, `${name}[${String(index)}]`));
 }
 
 function writeJson(response: ServerResponse, status: number, body: unknown): void {

--- a/packages/happy-desktop-electron/sources/main/openIn.ts
+++ b/packages/happy-desktop-electron/sources/main/openIn.ts
@@ -9,7 +9,7 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 /**
- * The applications a project directory can be handed to. The renderer only ever
+ * The applications workspace items can be handed to. The renderer only ever
  * names one of these ids: it never sends a bundle id, an executable, a flag, or
  * an argument, so nothing it says can become part of a command line. Everything
  * that does reach the command line is the fixed data below.
@@ -398,27 +398,50 @@ export async function openInTargetsRead(): Promise<readonly OpenInTarget[]> {
 }
 
 /**
- * Opens `directory` in the named application.
+ * Opens the selected local items in the named application.
  *
  * The bundle is addressed by the path detection found and confirmed, not by a
  * display name `open -a` would have to match and not by a LaunchServices id that
  * may resolve to a copy the reader cannot see. The argument array is passed to
  * `execFile` directly: there is no shell, so there is no quoting to get wrong.
  *
- * The caller is responsible for `directory` being a project root it has
- * independently authorized; this function does not take the renderer's word for
- * a path any more than it takes its word for an application.
+ * The caller is responsible for every item path being independently authorized;
+ * this function does not take the renderer's word for a path any more than it
+ * takes its word for an application.
  */
-export async function openInRun(targetId: string, directory: string): Promise<void> {
+export async function openInRun(
+    targetId: string,
+    itemPaths: string | readonly string[],
+): Promise<void> {
     if (process.platform !== "darwin")
-        throw new Error("Opening a project in another application is only supported on macOS.");
+        throw new Error(
+            "Opening workspace items in another application is only supported on macOS.",
+        );
+    const paths = typeof itemPaths === "string" ? [itemPaths] : itemPaths;
+    if (paths.length === 0) throw new Error("Nothing was supplied to open.");
     const target = OPEN_IN_APPS.find((candidate) => candidate.id === targetId);
-    if (!target) throw new Error("That application is not one this app can open projects in.");
+    if (!target)
+        throw new Error("That application is not one this app can open workspace items in.");
     const path = (await detectedRead()).get(target.id)?.path;
     if (path === undefined) throw new Error(`${target.label} does not appear to be installed.`);
     try {
-        await execFileAsync("/usr/bin/open", ["-a", path, directory], { timeout: 10_000 });
+        await execFileAsync("/usr/bin/open", ["-a", path, ...paths], { timeout: 10_000 });
     } catch {
-        throw new Error(`${target.label} could not open this project.`);
+        throw new Error(`${target.label} could not open the selected item.`);
+    }
+}
+
+/**
+ * Reveals each selected local item in Finder. `-R` selects the item rather than
+ * opening it, which gives files and directories the same familiar result.
+ */
+export async function revealInFileManager(paths: readonly string[]): Promise<void> {
+    if (process.platform !== "darwin")
+        throw new Error("Revealing a workspace item is only supported on macOS.");
+    if (paths.length === 0) throw new Error("Nothing was supplied to reveal.");
+    try {
+        await execFileAsync("/usr/bin/open", ["-R", ...paths], { timeout: 10_000 });
+    } catch {
+        throw new Error("Finder could not reveal the selected item.");
     }
 }

--- a/packages/happy-desktop-electron/sources/renderer/happyAgentCatalogSource.ts
+++ b/packages/happy-desktop-electron/sources/renderer/happyAgentCatalogSource.ts
@@ -136,6 +136,7 @@ function catalogProject(
                 orderKey: workspace.orderKey,
                 path: workspace.path,
                 displayPath: workspace.path,
+                ...(workspace.hostPath === undefined ? {} : { hostPath: workspace.hostPath }),
                 status: workspace.status,
                 presence: workspace.presence,
                 // The host's own sentence about a failed checkout, carried
@@ -171,6 +172,7 @@ function catalogProject(
         orderKey: bot.orderKey,
         path: bot.path,
         displayPath: bot.path,
+        ...(bot.hostPath === undefined ? {} : { hostPath: bot.hostPath }),
         ...(bot.avatar === undefined ? {} : { avatar: bot.avatar }),
     }));
     const catalog: HappyAgentProjectCatalog = { bots, projects, worktrees };
@@ -185,6 +187,7 @@ function projectProject(group: ProjectGroup, baseUrl: string): HappyAgentProject
         orderKey: group.orderKey,
         path: group.path,
         displayPath: group.path,
+        ...(group.hostPath === undefined ? {} : { hostPath: group.hostPath }),
         kind: group.kind,
         status: group.initializationStatus,
         presence: group.presence,

--- a/packages/happy-desktop-electron/sources/renderer/happyAgentConnection.ts
+++ b/packages/happy-desktop-electron/sources/renderer/happyAgentConnection.ts
@@ -267,6 +267,8 @@ export function happyAgentConnectionOpen(input: {
      * the catalog, and the desktop-local host routes alike.
      */
     readonly happyAgentHttpUrl: string;
+    /** Whether this connection's host paths belong to the desktop running this renderer. */
+    readonly nativeWorkspaceActions: boolean;
     /**
      * The window's appearance right now, read again for every terminal this
      * connection opens. A terminal is started in it and keeps it afterwards.
@@ -311,7 +313,10 @@ export function happyAgentConnectionOpen(input: {
         onTopLevelSessionFinished: () => completionChimePlay(),
     });
     const catalogSource = happyAgentCatalogSourceCreate(agentConnection, input.happyAgentHttpUrl);
-    const hostServices = happyAgentHostServicesCreate(input.happyAgentHttpUrl);
+    const hostServices = happyAgentHostServicesCreate(
+        input.happyAgentHttpUrl,
+        input.nativeWorkspaceActions,
+    );
     const client: HappyAgentWorkspaceClient = happyAgentWorkspaceClientCreate({
         client: directClient,
         cloudHost: input.cloudHost,

--- a/packages/happy-desktop-electron/sources/renderer/happyAgentDirectoryStore.ts
+++ b/packages/happy-desktop-electron/sources/renderer/happyAgentDirectoryStore.ts
@@ -208,6 +208,7 @@ export function happyAgentDirectoryStoreCreate(
             host,
             happyAgentId: LOCAL_HAPPY_AGENT_ID,
             happyAgentHttpUrl,
+            nativeWorkspaceActions: true,
             modelPreferencePersistence: deps.modelPreferencePersistence,
             terminalColorScheme: deps.terminalColorScheme,
             deps: {

--- a/packages/happy-desktop-electron/sources/renderer/happyAgentHostServices.ts
+++ b/packages/happy-desktop-electron/sources/renderer/happyAgentHostServices.ts
@@ -101,9 +101,13 @@ async function postJson<Value>(baseUrl: string, path: string, body: unknown): Pr
  * Renderer access to the small set of services that truly belong to the
  * desktop host. Agent resources use `HappyAgentClient` directly.
  */
-export function happyAgentHostServicesCreate(baseUrl: string): HappyAgentHostServices {
+export function happyAgentHostServicesCreate(
+    baseUrl: string,
+    nativeWorkspaceActions: boolean,
+): HappyAgentHostServices {
     const capability = capabilityOf(baseUrl);
     return {
+        nativeWorkspaceActions,
         openInTargetsRead: async (): Promise<HappyAgentOpenInTargets> => {
             const targets = await getJson<readonly HappyAgentOpenInTarget[]>(
                 baseUrl,
@@ -112,7 +116,7 @@ export function happyAgentHostServicesCreate(baseUrl: string): HappyAgentHostSer
             const recent = recentTargetRead();
             return { targets, ...(recent ? { recent } : {}) };
         },
-        openIn: async (workspaceId, target) => {
+        openIn: async (workspaceId, target, paths) => {
             // Remembered before the launch rather than after it. Choosing the
             // application is the reader's act and is already done; whether the
             // application then starts is the machine's business, and a slow or
@@ -122,6 +126,13 @@ export function happyAgentHostServicesCreate(baseUrl: string): HappyAgentHostSer
             await postJson<Record<string, never>>(baseUrl, "/open-in", {
                 workspaceId,
                 target: target.id,
+                ...(paths === undefined ? {} : { paths }),
+            });
+        },
+        workspacePathsReveal: async (workspaceId, paths) => {
+            await postJson<Record<string, never>>(baseUrl, "/workspace-paths-reveal", {
+                workspaceId,
+                paths,
             });
         },
         workspaceFileBytesRead: async (

--- a/packages/happy-desktop-state/src/happyAgent/happyAgentClient.ts
+++ b/packages/happy-desktop-state/src/happyAgent/happyAgentClient.ts
@@ -119,6 +119,8 @@ export interface HappyAgentWorkspaceFilesChanged {
 }
 
 export interface HappyAgentWorkspaceClient {
+    /** Whether native path actions address the same machine as this connection. */
+    readonly nativeWorkspaceActions: boolean;
     /** One model/capability/default/last-used authority for this daemon connection. */
     readonly models: HappyAgentModelStore;
     /**
@@ -256,11 +258,14 @@ export interface HappyAgentWorkspaceClient {
     projectAdd(path: string): Promise<HappyAgentProjectId>;
     /** Applications this host can open a project or worktree directory in. */
     openInTargetsRead(): Promise<HappyAgentOpenInTargets>;
-    /**
-     * Opens one project or worktree root in one of those applications, and makes
-     * it the one this machine opened most recently.
-     */
-    openIn(groupId: HappyAgentGroupId, target: HappyAgentOpenInTarget): Promise<void>;
+    /** Opens a group root or selected relative items in an installed application. */
+    openIn(
+        groupId: HappyAgentGroupId,
+        target: HappyAgentOpenInTarget,
+        paths?: readonly string[],
+    ): Promise<void>;
+    /** Reveals workspace-relative items in this machine's file manager. */
+    workspacePathsReveal(groupId: HappyAgentGroupId, paths: readonly string[]): Promise<void>;
     /** Reads one changed text file from a project/worktree checkout. */
     changedFileRead(
         groupId: HappyAgentGroupId,
@@ -474,6 +479,7 @@ export function happyAgentWorkspaceClientCreate(
     };
 
     return {
+        nativeWorkspaceActions: deps.hostServices.nativeWorkspaceActions,
         models,
         memory,
         catalogRead: () => models.load().then((snapshot) => snapshot.catalog),
@@ -535,7 +541,9 @@ export function happyAgentWorkspaceClientCreate(
             }
         },
         openInTargetsRead: () => deps.hostServices.openInTargetsRead(),
-        openIn: (groupId, target) => deps.hostServices.openIn(groupId, target),
+        openIn: (groupId, target, paths) => deps.hostServices.openIn(groupId, target, paths),
+        workspacePathsReveal: (groupId, paths) =>
+            deps.hostServices.workspacePathsReveal(groupId, paths),
         sessionList() {
             if (disposed) throw new Error("The Happy Agent client is disposed.");
             if (!sessionListStore) {

--- a/packages/happy-desktop-state/src/happyAgent/happyAgentHostServices.ts
+++ b/packages/happy-desktop-state/src/happyAgent/happyAgentHostServices.ts
@@ -17,14 +17,25 @@ import type {
  * attaching the terminal's binary WebSocket protocol.
  */
 export interface HappyAgentHostServices {
+    /**
+     * Whether native path actions address the same machine as this connection.
+     * A node connection must answer false even when that node reports host paths.
+     */
+    readonly nativeWorkspaceActions: boolean;
     openInTargetsRead(): Promise<HappyAgentOpenInTargets>;
     /**
-     * Hands the group's directory to that application, and records it as the one
-     * this machine opened a project in most recently. The whole target is passed
-     * because the host is what remembers the choice across a reload, and the
-     * control that wears it needs the label and the icon, not only the id.
+     * Hands the group's directory, or selected workspace-relative items, to
+     * that application and records it as the one most recently chosen. The full
+     * target travels through this boundary because the host remembers the
+     * choice across a reload, and its control needs the label and icon too.
      */
-    openIn(groupId: HappyAgentGroupId, target: HappyAgentOpenInTarget): Promise<void>;
+    openIn(
+        groupId: HappyAgentGroupId,
+        target: HappyAgentOpenInTarget,
+        paths?: readonly string[],
+    ): Promise<void>;
+    /** Reveals workspace-relative items in this machine's file manager. */
+    workspacePathsReveal(groupId: HappyAgentGroupId, paths: readonly string[]): Promise<void>;
     workspaceFileBytesRead(
         groupId: HappyAgentGroupId,
         path: string,

--- a/packages/happy-desktop-state/src/happyAgent/happyAgentProjectGroupProject.ts
+++ b/packages/happy-desktop-state/src/happyAgent/happyAgentProjectGroupProject.ts
@@ -62,6 +62,8 @@ export interface HappyAgentWorktreeGroup {
     readonly orderKey: string;
     readonly path: string;
     readonly displayPath: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    readonly hostPath?: string;
     /**
      * Whether this worktree's checkout is being prepared, usable, gone, or was
      * never made at all. Every row carries one: a worktree that exists is always
@@ -101,6 +103,8 @@ export interface HappyAgentProjectGroup {
     readonly orderKey: string;
     readonly path: string;
     readonly displayPath: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    readonly hostPath?: string;
     /** `home` is the catch-all project for sessions started outside any repository. */
     readonly kind: "regular" | "home";
     /** Whether this project's checkout is being prepared, usable, gone, or failed. */
@@ -183,6 +187,7 @@ export function happyAgentProjectGroupsProject(
             orderKey: worktree.orderKey,
             path: worktree.path,
             displayPath: worktree.displayPath,
+            ...(worktree.hostPath === undefined ? {} : { hostPath: worktree.hostPath }),
             lifecycle: happyAgentWorktreeLifecycleOf(worktree),
             ...(worktreeRefusal === undefined ? {} : { writeRefusal: worktreeRefusal }),
             conversations,
@@ -279,6 +284,7 @@ function projectGroup(
         orderKey: project.orderKey,
         path: project.path,
         displayPath: project.displayPath,
+        ...(project.hostPath === undefined ? {} : { hostPath: project.hostPath }),
         kind: project.kind,
         lifecycle: happyAgentProjectLifecycleOf(project),
         conversations,

--- a/packages/happy-desktop-state/src/happyAgent/happyAgentTypes.ts
+++ b/packages/happy-desktop-state/src/happyAgent/happyAgentTypes.ts
@@ -69,6 +69,8 @@ export interface HappyAgentBot {
     readonly orderKey: string;
     readonly path: string;
     readonly displayPath: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    readonly hostPath?: string;
     /**
      * The bot's picture. Unlike a project avatar it has no intrinsic size: the
      * daemon serves the bytes and a thumbhash to stand in until they arrive,
@@ -391,6 +393,8 @@ export interface HappyAgentProject {
     readonly path: string;
     /** Presentation path (home-relative when the daemon's host supplied one). */
     readonly displayPath: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    readonly hostPath?: string;
     /** `home` is the catch-all project for sessions started outside any repository. */
     readonly kind: "regular" | "home";
     /** Whether the daemon has finished deriving the project's name and picture. */
@@ -459,6 +463,8 @@ export interface HappyAgentWorktree {
     readonly orderKey: string;
     readonly path: string;
     readonly displayPath: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    readonly hostPath?: string;
     readonly status: "initializing" | "ready" | "failed" | "archiving" | "archived";
     /**
      * Whether the checkout this worktree names is still on disk. The host

--- a/packages/happy-desktop-state/src/happyAgent/happyAgentWorkspaceStore.ts
+++ b/packages/happy-desktop-state/src/happyAgent/happyAgentWorkspaceStore.ts
@@ -571,6 +571,11 @@ export interface HappyAgentWorkspaceSnapshot {
      */
     readonly groupSessionDraft?: HappyAgentSessionDraftSnapshot;
     /**
+     * Whether native path actions address the same machine as this connection.
+     * A host path alone is not enough: a remote Happy Agent also reports host paths.
+     */
+    readonly nativeWorkspaceActions: boolean;
+    /**
      * Applications the host can open the addressed group's directory in, read
      * once per workspace and empty until then. Empty is also the honest answer
      * on a host that offers none, and the surface shows no menu rather than an
@@ -1223,6 +1228,14 @@ export interface HappyAgentWorkspaceStore {
      * has answered.
      */
     openIn(groupId: HappyAgentGroupId, target: HappyAgentOpenInTarget): Promise<void>;
+    /** Opens workspace-relative items in one installed application. */
+    workspacePathsOpenIn(
+        groupId: HappyAgentGroupId,
+        paths: readonly string[],
+        target: HappyAgentOpenInTarget,
+    ): Promise<void>;
+    /** Reveals workspace-relative items in this machine's file manager. */
+    workspacePathsReveal(groupId: HappyAgentGroupId, paths: readonly string[]): Promise<void>;
     /**
      * Materializes the Create surface, on the group last created in — or the one
      * given, when it is asked for from somewhere that already knows where. A task
@@ -1790,6 +1803,7 @@ export function happyAgentWorkspaceStoreCreate(
         recentTabs: client.memory.recentTabsRead(),
         tabOrder,
         groupResume,
+        nativeWorkspaceActions: client.nativeWorkspaceActions,
         openInTargets,
         fileViewMode,
         fileViewWrap,
@@ -2176,6 +2190,7 @@ export function happyAgentWorkspaceStoreCreate(
                 snapshot.displayedMainViewId === displayedMainViewId &&
                 snapshot.panelFile === panelFile &&
                 snapshot.groupResume === groupResume &&
+                snapshot.nativeWorkspaceActions === client.nativeWorkspaceActions &&
                 snapshot.openInTargets === openInTargets &&
                 snapshot.openInRecent === openInRecent &&
                 snapshot.rename === rename &&
@@ -2205,6 +2220,7 @@ export function happyAgentWorkspaceStoreCreate(
                           recentTabs,
                           tabOrder,
                           groupResume,
+                          nativeWorkspaceActions: client.nativeWorkspaceActions,
                           openInTargets,
                           fileViewMode,
                           fileViewWrap,
@@ -4169,6 +4185,7 @@ export function happyAgentWorkspaceStoreCreate(
                     recentTabs: client.memory.recentTabsRead(),
                     tabOrder,
                     groupResume,
+                    nativeWorkspaceActions: client.nativeWorkspaceActions,
                     openInTargets,
                     fileViewMode,
                     fileViewWrap,
@@ -5083,6 +5100,14 @@ export function happyAgentWorkspaceStoreCreate(
             }
             return client.openIn(groupId, target);
         },
+        workspacePathsOpenIn: (groupId, paths, target) => {
+            if (openInRecent?.id !== target.id) {
+                openInRecent = target;
+                recompute();
+            }
+            return client.openIn(groupId, target, paths);
+        },
+        workspacePathsReveal: (groupId, paths) => client.workspacePathsReveal(groupId, paths),
         createOpen(groupId) {
             // Asking for the surface while it is already materialized — coming
             // back to it, or the row action behind it — must not throw away what

--- a/packages/happy-desktop-state/src/happyAgentConnection/projection.ts
+++ b/packages/happy-desktop-state/src/happyAgentConnection/projection.ts
@@ -405,6 +405,7 @@ export function projectGroups(
                     : { branch: project.git.branch }),
                 orderKey: project.orderKey,
                 path: computePath(project.compute),
+                ...(project.compute.type === "host" ? { hostPath: project.compute.path } : {}),
                 presence: "present",
                 ...(project.initialization.error === null
                     ? {}
@@ -487,6 +488,7 @@ export function projectBots(
                 username: bot.username,
                 orderKey: bot.orderKey,
                 path: computePath(bot.compute),
+                ...(bot.compute.type === "host" ? { hostPath: bot.compute.path } : {}),
                 ...(bot.avatar === null
                     ? {}
                     : {
@@ -533,6 +535,7 @@ function projectWorkspace(
         name: workspace.name,
         orderKey: workspace.orderKey,
         path: computePath(workspace.compute),
+        ...(workspace.compute.type === "host" ? { hostPath: workspace.compute.path } : {}),
         presence: "present",
         projectId,
         status: workspace.initialization.status,

--- a/packages/happy-desktop-state/src/happyAgentConnection/types.ts
+++ b/packages/happy-desktop-state/src/happyAgentConnection/types.ts
@@ -544,6 +544,8 @@ export interface WorkspaceGroup {
     name: string;
     orderKey: string;
     path: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    hostPath?: string;
     presence: "present" | "missing";
     projectId: string;
     status: "initializing" | "ready" | "failed";
@@ -561,6 +563,8 @@ export interface ProjectGroup {
     branch?: string;
     orderKey: string;
     path: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    hostPath?: string;
     presence: "present" | "missing";
     initializationError?: string;
     initializationStatus: "initializing" | "ready" | "failed";
@@ -594,6 +598,8 @@ export interface BotGroup {
     username: string;
     orderKey: string;
     path: string;
+    /** Canonical path on this Happy Agent's host, absent for Docker compute. */
+    hostPath?: string;
     /** Present when the bot has a picture; the bytes are fetched separately. */
     avatar?: { url: string; thumbhash: string };
     /** The bot's one permanent conversation. */

--- a/packages/happy-desktop-ui/dev/pages/FileTreePage.tsx
+++ b/packages/happy-desktop-ui/dev/pages/FileTreePage.tsx
@@ -1,4 +1,6 @@
-import { FileTree, type FileTreeNode } from "../../src/FileTree";
+import type { ContextMenuSelectionResult } from "../../src/ContextMenu";
+import { FileTree, type FileTreeContextSelection, type FileTreeNode } from "../../src/FileTree";
+import type { MenuItem } from "../../src/Menu";
 import { ComponentPage, DimensionRule, Specimen } from "../kit";
 
 /** The component plan this page documents. The selector and the page header read the same value. */
@@ -65,6 +67,8 @@ const collapsedNodes: FileTreeNode[] = [
     { id: "package.json", name: "package.json", kind: "file" },
 ];
 
+const sampleSelectedIds = new Set(["src/index.ts", "src/theme.css"]);
+
 /** Enough rows that drawing all of them would be the wrong thing to do. */
 const manyNodes: FileTreeNode[] = Array.from({ length: 2000 }, (_, index) => ({
     id: `src/module-${String(index)}.ts`,
@@ -88,11 +92,35 @@ function frame(children: ReturnType<typeof FileTree>, width = 320) {
     );
 }
 
+function rowMenuItems(selection: FileTreeContextSelection): readonly MenuItem[] {
+    return [
+        { kind: "item", id: "open", label: "Open", icon: "doc" },
+        { kind: "item", id: "reveal", label: "Show in Finder", icon: "eye" },
+        { kind: "separator" },
+        {
+            kind: "item",
+            id: "copy-relative-path",
+            label: selection.entries.length > 1 ? "Copy relative paths" : "Copy relative path",
+            icon: "copy",
+        },
+    ];
+}
+
+function rowMenuSelect(
+    selection: FileTreeContextSelection,
+    actionId: string,
+): Promise<ContextMenuSelectionResult> | undefined {
+    if (actionId !== "copy-relative-path") return undefined;
+    return navigator.clipboard
+        .writeText(selection.entries.map((entry) => entry.id).join("\n"))
+        .then(() => ({ feedback: "Relative path copied" }));
+}
+
 export function FileTreePage() {
     return (
         <ComponentPage
             number={componentNumber}
-            summary="A props-only file/folder explorer: 28px rows, chevron disclosure for directories, 16px-per-level indentation, file-type icons resolved from each name, git-status decorations, selection, and a 'Show more' paging affordance."
+            summary="A props-only file/folder explorer: 28px rows, chevron disclosure for directories, 16px-per-level indentation, file-type icons resolved from each name, git-status decorations, selection, right-click actions, and a 'Show more' paging affordance."
             title="FileTree"
         >
             <Specimen
@@ -108,7 +136,10 @@ export function FileTreePage() {
                             onLoadMore={() => {}}
                             onSelect={() => {}}
                             onToggle={() => {}}
+                            onRowMenuSelect={rowMenuSelect}
+                            rowMenuItems={rowMenuItems}
                             selectedId="src/index.ts"
+                            selectedIds={sampleSelectedIds}
                         />,
                     )}
                     <DimensionRule label="320 px panel · 28 px row · 16 px indent per level" />

--- a/packages/happy-desktop-ui/src/ContextMenu.tsx
+++ b/packages/happy-desktop-ui/src/ContextMenu.tsx
@@ -1,0 +1,183 @@
+import { useLayoutEffect, useRef, useState, type KeyboardEvent } from "react";
+import { Menu, type MenuItem } from "./Menu";
+
+export interface ContextMenuPlacement {
+    /** Viewport coordinates of the gesture that opened the menu. */
+    readonly x: number;
+    readonly y: number;
+}
+
+export type ContextMenuDismissReason = "escape" | "outside" | "resize" | "select";
+
+/** Returning feedback keeps the menu open and briefly confirms that item. */
+export interface ContextMenuSelectionFeedback {
+    readonly feedback: string;
+}
+
+export type ContextMenuSelectionResult = ContextMenuSelectionFeedback | void;
+
+export interface ContextMenuProps {
+    readonly items: readonly MenuItem[];
+    readonly placement: ContextMenuPlacement;
+    readonly onSelect: (
+        actionId: string,
+    ) => ContextMenuSelectionResult | Promise<ContextMenuSelectionResult>;
+    readonly onDismiss: (reason: ContextMenuDismissReason) => void;
+    readonly width?: number;
+}
+
+/** Kept clear of the viewport edge so a clamped menu never sits flush. */
+const EDGE_INSET = 8;
+const FEEDBACK_MS = 1_600;
+
+/** Every enabled command in visual order. */
+function menuCommands(root: HTMLElement | null): HTMLButtonElement[] {
+    return [
+        ...(root?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)') ?? []),
+    ];
+}
+
+/**
+ * ContextMenu — one Menu positioned at a pointer or keyboard-invoked row,
+ * clamped into the viewport, focused on arrival, and dismissed by selection,
+ * an outside press, Escape, or a resize.
+ *
+ * A selection may return brief feedback. That keeps the menu open, turns the
+ * chosen row into a check, and leaves a failed promise unchanged and retryable.
+ */
+export function ContextMenu(props: ContextMenuProps) {
+    const root = useRef<HTMLDivElement>(null);
+    const feedbackTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const selection = useRef(0);
+    const focused = useRef(false);
+    const dismiss = useRef(props.onDismiss);
+    const [placement, placementSet] = useState(props.placement);
+    const [feedback, feedbackSet] = useState<
+        { readonly id: string; readonly label: string } | undefined
+    >(undefined);
+    // eslint-disable-next-line happy-react/no-layout-effect -- global listeners need the newest owner callback without restarting the menu lifecycle or its feedback timer
+    useLayoutEffect(() => {
+        dismiss.current = props.onDismiss;
+    });
+    // eslint-disable-next-line happy-react/no-layout-effect -- the popover must measure its drawn height before clamping to the viewport, then owns global dismissal listeners for exactly its mounted lifetime
+    useLayoutEffect(() => {
+        const bounds = root.current?.getBoundingClientRect();
+        if (bounds) {
+            const x = Math.max(
+                EDGE_INSET,
+                Math.min(placement.x, window.innerWidth - bounds.width - EDGE_INSET),
+            );
+            const y = Math.max(
+                EDGE_INSET,
+                Math.min(placement.y, window.innerHeight - bounds.height - EDGE_INSET),
+            );
+            if (x !== placement.x || y !== placement.y) {
+                placementSet({ x, y });
+                return;
+            }
+        }
+        if (!focused.current) {
+            focused.current = true;
+            menuCommands(root.current)[0]?.focus();
+        }
+        const close = (event: Event) => {
+            if (!root.current?.contains(event.target as Node)) dismiss.current("outside");
+        };
+        const closeOnEscape = (event: globalThis.KeyboardEvent) => {
+            if (event.key !== "Escape") return;
+            event.preventDefault();
+            dismiss.current("escape");
+        };
+        const dismissOnResize = () => dismiss.current("resize");
+        document.addEventListener("pointerdown", close);
+        document.addEventListener("keydown", closeOnEscape);
+        window.addEventListener("resize", dismissOnResize);
+        return () => {
+            document.removeEventListener("pointerdown", close);
+            document.removeEventListener("keydown", closeOnEscape);
+            window.removeEventListener("resize", dismissOnResize);
+            if (feedbackTimer.current !== undefined) clearTimeout(feedbackTimer.current);
+        };
+    }, [placement]);
+
+    const keyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+        if (
+            event.key !== "ArrowDown" &&
+            event.key !== "ArrowUp" &&
+            event.key !== "Home" &&
+            event.key !== "End"
+        )
+            return;
+        const commands = menuCommands(root.current);
+        if (commands.length === 0) return;
+        event.preventDefault();
+        const current = commands.indexOf(document.activeElement as HTMLButtonElement);
+        const index =
+            event.key === "Home"
+                ? 0
+                : event.key === "End"
+                  ? commands.length - 1
+                  : event.key === "ArrowDown"
+                    ? current < 0
+                        ? 0
+                        : (current + 1) % commands.length
+                    : current < 0
+                      ? commands.length - 1
+                      : (current - 1 + commands.length) % commands.length;
+        commands[index]?.focus();
+    };
+
+    const items = props.items.map((item): MenuItem => {
+        if (item.kind !== "item" || item.id !== feedback?.id) return item;
+        const { iconUrl: _iconUrl, ...rest } = item;
+        return { ...rest, icon: "check", label: feedback.label };
+    });
+    return (
+        <div
+            className="happy-context-menu"
+            data-feedback={feedback ? "" : undefined}
+            data-happy-desktop-ui="context-menu"
+            onContextMenu={(event) => event.preventDefault()}
+            onKeyDown={keyDown}
+            ref={root}
+            style={{ left: placement.x, top: placement.y }}
+        >
+            <Menu
+                items={items}
+                onSelect={(actionId) => {
+                    const current = selection.current + 1;
+                    selection.current = current;
+                    let result: ContextMenuSelectionResult | Promise<ContextMenuSelectionResult>;
+                    try {
+                        result = props.onSelect(actionId);
+                    } catch {
+                        return;
+                    }
+                    void Promise.resolve(result).then(
+                        (result) => {
+                            if (!root.current || selection.current !== current) return;
+                            if (result === undefined) {
+                                dismiss.current("select");
+                                return;
+                            }
+                            feedbackSet({ id: actionId, label: result.feedback });
+                            if (feedbackTimer.current !== undefined)
+                                clearTimeout(feedbackTimer.current);
+                            feedbackTimer.current = setTimeout(() => {
+                                feedbackTimer.current = undefined;
+                                feedbackSet(undefined);
+                            }, FEEDBACK_MS);
+                        },
+                        () => {
+                            // Clipboard and native-host failures leave the item retryable.
+                        },
+                    );
+                }}
+                width={props.width ?? 224}
+            />
+            <span aria-live="polite" className="happy-visually-hidden" role="status">
+                {feedback?.label ?? ""}
+            </span>
+        </div>
+    );
+}

--- a/packages/happy-desktop-ui/src/FileBrowser.tsx
+++ b/packages/happy-desktop-ui/src/FileBrowser.tsx
@@ -21,12 +21,15 @@ export type FileBrowserProps = {
     /** Rows to list. Passed straight through to FileTree. */
     nodes: readonly FileTreeNode[];
     selectedId?: FileTreeProps["selectedId"];
+    selectedIds?: FileTreeProps["selectedIds"];
     onSelect?: FileTreeProps["onSelect"];
     onOpen?: FileTreeProps["onOpen"];
     onToggle?: FileTreeProps["onToggle"];
     onDirectoryPrefetch?: FileTreeProps["onDirectoryPrefetch"];
     onFilePrefetch?: FileTreeProps["onFilePrefetch"];
     onLoadMore?: FileTreeProps["onLoadMore"];
+    rowMenuItems?: FileTreeProps["rowMenuItems"];
+    onRowMenuSelect?: FileTreeProps["onRowMenuSelect"];
     loading?: boolean;
     loadingLabel?: string;
     emptyLabel?: string;
@@ -72,12 +75,15 @@ export function FileBrowser(props: FileBrowserProps) {
         "onLayoutChange",
         "nodes",
         "selectedId",
+        "selectedIds",
         "onSelect",
         "onOpen",
         "onToggle",
         "onDirectoryPrefetch",
         "onFilePrefetch",
         "onLoadMore",
+        "rowMenuItems",
+        "onRowMenuSelect",
         "loading",
         "loadingLabel",
         "emptyLabel",
@@ -197,9 +203,12 @@ export function FileBrowser(props: FileBrowserProps) {
                     onFilePrefetch={local.onFilePrefetch}
                     onLoadMore={local.onLoadMore}
                     onOpen={local.onOpen}
+                    onRowMenuSelect={local.onRowMenuSelect}
                     onSelect={local.onSelect}
                     onToggle={local.onToggle}
+                    rowMenuItems={local.rowMenuItems}
                     selectedId={local.selectedId}
+                    selectedIds={local.selectedIds}
                     virtualize
                 />
             </div>

--- a/packages/happy-desktop-ui/src/FileTree.tsx
+++ b/packages/happy-desktop-ui/src/FileTree.tsx
@@ -1,8 +1,17 @@
 import { partitionComponentProps } from "./componentProps";
-import { useCallback, useRef, useState, type CSSProperties, type KeyboardEvent } from "react";
+import {
+    useCallback,
+    useRef,
+    useState,
+    type CSSProperties,
+    type KeyboardEvent,
+    type MouseEvent,
+} from "react";
 import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual";
 import { compactCount, changeCountLabel } from "./countText";
+import { ContextMenu, type ContextMenuSelectionResult } from "./ContextMenu";
 import { Icon } from "./Icon";
+import { type MenuItem } from "./Menu";
 import { fileTreeRowModel, type FileTreeRow } from "./fileTreeRows";
 import { ScrollArea } from "./Scrollbar";
 import { Ionicon, type IoniconName } from "./vectorIcons/VectorIcon";
@@ -56,6 +65,15 @@ export type FileTreeSelectModifiers = {
     /** Shift: take the run of rows from the last one picked through this one. */
     readonly extend: boolean;
 };
+/**
+ * The exact row that opened a context menu and the entries its action covers.
+ * Right-clicking inside the current picked set keeps that set; right-clicking
+ * anywhere else addresses only that row without selecting or opening it first.
+ */
+export interface FileTreeContextSelection {
+    readonly anchor: FileTreeNode;
+    readonly entries: readonly FileTreeNode[];
+}
 export type FileTreeProps = {
     className?: string;
     "data-testid"?: string;
@@ -86,6 +104,13 @@ export type FileTreeProps = {
     onFilePrefetch?: (id: string) => void;
     /** Directory paging request (the "Show more" affordance). */
     onLoadMore?: (id: string) => void;
+    /** Returns the replacement menu for one row/selection. Empty keeps the native menu. */
+    rowMenuItems?: (selection: FileTreeContextSelection) => readonly MenuItem[];
+    /** Runs one row-menu command; feedback keeps the menu open long enough to confirm it. */
+    onRowMenuSelect?: (
+        selection: FileTreeContextSelection,
+        actionId: string,
+    ) => ContextMenuSelectionResult | Promise<ContextMenuSelectionResult>;
     /** Why file-row selection/opening is unavailable while directory disclosure remains local. */
     filesUnavailable?: string;
     /** Per-depth indentation step. Defaults to 16px. */
@@ -464,6 +489,7 @@ interface FileTreeRowViewProps {
     onDirectoryPrefetch?: (id: string) => void;
     onFilePrefetch?: (id: string) => void;
     onLoadMore?: (id: string) => void;
+    onContextMenu?: (node: FileTreeNode, event: MouseEvent<HTMLDivElement>) => void;
     filesUnavailable?: string;
     onFocusRow: (id: string) => void;
     onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
@@ -571,6 +597,9 @@ function FileTreeRowView(props: FileTreeRowViewProps) {
                 if (row.kind === "entry" && !directory && props.filesUnavailable === undefined)
                     onOpen?.(node.id);
             }}
+            onContextMenu={(event) => {
+                if (row.kind === "entry") props.onContextMenu?.(node, event);
+            }}
             onFocus={() => {
                 onFocusRow(row.id);
                 if (row.kind === "entry" && directory) onDirectoryPrefetch?.(node.id);
@@ -675,6 +704,8 @@ export function FileTree(props: FileTreeProps) {
         "onDirectoryPrefetch",
         "onFilePrefetch",
         "onLoadMore",
+        "rowMenuItems",
+        "onRowMenuSelect",
         "filesUnavailable",
         "indent",
         "virtualize",
@@ -695,6 +726,43 @@ export function FileTree(props: FileTreeProps) {
      * one, or every notification would drag the focus somewhere.
      */
     const [focusedRow, focusedRowSet] = useState<string | undefined>(undefined);
+    /** One transient menu, kept outside the virtualized scrollport that opened it. */
+    const [rowMenu, rowMenuSet] = useState<
+        | {
+              readonly selection: FileTreeContextSelection;
+              readonly items: readonly MenuItem[];
+              readonly opener: HTMLDivElement;
+              readonly x: number;
+              readonly y: number;
+          }
+        | undefined
+    >(undefined);
+    const contextSelection = (anchor: FileTreeNode): FileTreeContextSelection => {
+        if (local.selectedIds?.has(anchor.id) !== true) return { anchor, entries: [anchor] };
+        const entries = model.rows.flatMap((row) =>
+            row.kind === "entry" && local.selectedIds?.has(row.node.id) === true ? [row.node] : [],
+        );
+        return { anchor, entries: entries.length === 0 ? [anchor] : entries };
+    };
+    const rowMenuOpen = (
+        node: FileTreeNode,
+        opener: HTMLDivElement,
+        pointer?: { readonly x: number; readonly y: number },
+    ): boolean => {
+        const selection = contextSelection(node);
+        const items = local.rowMenuItems?.(selection) ?? [];
+        // With no usable replacement, leave the platform menu in place.
+        if (!items.some((item) => item.kind === "item" && item.disabled !== true)) return false;
+        const bounds = opener.getBoundingClientRect();
+        const x = pointer && (pointer.x !== 0 || pointer.y !== 0) ? pointer.x : bounds.left + 24;
+        const y =
+            pointer && (pointer.x !== 0 || pointer.y !== 0)
+                ? pointer.y
+                : bounds.top + Math.min(bounds.height, 28);
+        opener.focus({ preventScroll: true });
+        rowMenuSet({ selection, items, opener, x, y });
+        return true;
+    };
     /**
      * A row that has been asked for but is not drawn yet. Moving to a row a
      * long way down a virtualized listing has to scroll it into existence
@@ -787,6 +855,13 @@ export function FileTree(props: FileTreeProps) {
     };
     const keyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
         if (event.altKey || event.ctrlKey || event.metaKey) return;
+        if ((event.shiftKey && event.key === "F10") || event.key === "ContextMenu") {
+            const contextIndex = model.indexById.get(event.currentTarget.dataset.row ?? "");
+            const contextRow = contextIndex === undefined ? undefined : model.rows[contextIndex];
+            if (contextRow?.kind === "entry" && rowMenuOpen(contextRow.node, event.currentTarget))
+                event.preventDefault();
+            return;
+        }
         if (activeRow === undefined) return;
         const index = model.indexById.get(activeRow);
         if (index === undefined) return;
@@ -864,6 +939,10 @@ export function FileTree(props: FileTreeProps) {
             onFocusRow={focusedRowSet}
             filesUnavailable={local.filesUnavailable}
             onKeyDown={keyDown}
+            onContextMenu={(node, event) => {
+                if (rowMenuOpen(node, event.currentTarget, { x: event.clientX, y: event.clientY }))
+                    event.preventDefault();
+            }}
             onDirectoryPrefetch={local.onDirectoryPrefetch}
             onFilePrefetch={local.onFilePrefetch}
             onLoadMore={local.onLoadMore}
@@ -878,67 +957,86 @@ export function FileTree(props: FileTreeProps) {
         />
     );
     return (
-        <ScrollArea
-            className={["happy-file-tree", local.className].filter(Boolean).join(" ")}
-            data-happy-desktop-ui="file-tree"
-            data-testid={local["data-testid"]}
-            data-virtualized={virtualized ? "" : undefined}
-            // Virtualized is exactly when this element owns the scrolling, so it
-            // is exactly when it needs the bar beside its rows rather than over
-            // them. Unvirtualized, the panel around it scrolls and marks itself.
-            data-scrollbar-rows={virtualized ? "" : undefined}
-            style={local.style}
-            viewportClassName="happy-file-tree__viewport"
-            viewportProps={{
-                "aria-label": local.label ?? "Files",
-                "aria-multiselectable": local.selectedIds ? true : undefined,
-                role: "tree",
-                // The rows carry the tab stop between them; the tree itself is
-                // reachable on purpose, never by tabbing past the listing.
-                tabIndex: -1,
-            }}
-            viewportRef={scrollElement}
-        >
-            {local.loading ? (
-                <div
-                    className="happy-file-tree__status-line"
-                    data-happy-desktop-ui="file-tree-status-line"
-                >
-                    {local.loadingLabel ?? "Loading files…"}
-                </div>
-            ) : model.rows.length === 0 ? (
-                <div
-                    className="happy-file-tree__status-line"
-                    data-happy-desktop-ui="file-tree-empty"
-                >
-                    {local.emptyLabel ?? "No files to show."}
-                </div>
-            ) : virtualized ? (
-                <div className="happy-file-tree__virtual" data-happy-desktop-ui="file-tree-virtual">
-                    {/* The rows leave the flow so the listing can be as tall as
+        <>
+            <ScrollArea
+                className={["happy-file-tree", local.className].filter(Boolean).join(" ")}
+                data-happy-desktop-ui="file-tree"
+                data-testid={local["data-testid"]}
+                data-virtualized={virtualized ? "" : undefined}
+                // Virtualized is exactly when this element owns the scrolling, so it
+                // is exactly when it needs the bar beside its rows rather than over
+                // them. Unvirtualized, the panel around it scrolls and marks itself.
+                data-scrollbar-rows={virtualized ? "" : undefined}
+                style={local.style}
+                viewportClassName="happy-file-tree__viewport"
+                viewportProps={{
+                    "aria-label": local.label ?? "Files",
+                    "aria-multiselectable": local.selectedIds ? true : undefined,
+                    role: "tree",
+                    // The rows carry the tab stop between them; the tree itself is
+                    // reachable on purpose, never by tabbing past the listing.
+                    tabIndex: -1,
+                }}
+                viewportRef={scrollElement}
+            >
+                {local.loading ? (
+                    <div
+                        className="happy-file-tree__status-line"
+                        data-happy-desktop-ui="file-tree-status-line"
+                    >
+                        {local.loadingLabel ?? "Loading files…"}
+                    </div>
+                ) : model.rows.length === 0 ? (
+                    <div
+                        className="happy-file-tree__status-line"
+                        data-happy-desktop-ui="file-tree-empty"
+                    >
+                        {local.emptyLabel ?? "No files to show."}
+                    </div>
+                ) : virtualized ? (
+                    <div
+                        className="happy-file-tree__virtual"
+                        data-happy-desktop-ui="file-tree-virtual"
+                    >
+                        {/* The rows leave the flow so the listing can be as tall as
                         all of them while only the drawn ones exist; this box is
                         what holds that height open. */}
-                    <div
-                        className="happy-file-tree__virtual-sizer"
-                        style={{ height: `${String(virtualizer.getTotalSize())}px` }}
-                    >
-                        {virtualizer.getVirtualItems().map((item) => {
-                            const row = model.rows[item.index];
-                            return row ? (
-                                <div
-                                    className="happy-file-tree__virtual-row"
-                                    key={item.key}
-                                    style={{ transform: `translateY(${String(item.start)}px)` }}
-                                >
-                                    {rowView(row)}
-                                </div>
-                            ) : null;
-                        })}
+                        <div
+                            className="happy-file-tree__virtual-sizer"
+                            style={{ height: `${String(virtualizer.getTotalSize())}px` }}
+                        >
+                            {virtualizer.getVirtualItems().map((item) => {
+                                const row = model.rows[item.index];
+                                return row ? (
+                                    <div
+                                        className="happy-file-tree__virtual-row"
+                                        key={item.key}
+                                        style={{ transform: `translateY(${String(item.start)}px)` }}
+                                    >
+                                        {rowView(row)}
+                                    </div>
+                                ) : null;
+                            })}
+                        </div>
                     </div>
-                </div>
-            ) : (
-                model.rows.map(rowView)
-            )}
-        </ScrollArea>
+                ) : (
+                    model.rows.map(rowView)
+                )}
+            </ScrollArea>
+            {rowMenu && model.indexById.has(rowMenu.selection.anchor.id) ? (
+                <ContextMenu
+                    items={rowMenu.items}
+                    key={`${rowMenu.selection.anchor.id}:${String(rowMenu.x)}:${String(rowMenu.y)}`}
+                    onDismiss={(reason) => {
+                        const opener = rowMenu.opener;
+                        rowMenuSet(undefined);
+                        if (reason === "escape" && opener.isConnected)
+                            opener.focus({ preventScroll: true });
+                    }}
+                    onSelect={(actionId) => local.onRowMenuSelect?.(rowMenu.selection, actionId)}
+                    placement={{ x: rowMenu.x, y: rowMenu.y }}
+                />
+            ) : null}
+        </>
     );
 }

--- a/packages/happy-desktop-ui/src/Menu.tsx
+++ b/packages/happy-desktop-ui/src/Menu.tsx
@@ -15,6 +15,8 @@ export type MenuItem =
           iconUrl?: string;
           danger?: boolean;
           disabled?: boolean;
+          /** Why a visible command cannot run, announced and shown as its tooltip. */
+          disabledReason?: string;
           shortcut?: string;
       }
     | {
@@ -92,6 +94,11 @@ export function Menu(props: MenuProps) {
                         }
                         return (
                             <button
+                                aria-label={
+                                    item.disabled && item.disabledReason
+                                        ? `${item.label}. ${item.disabledReason}`
+                                        : undefined
+                                }
                                 aria-disabled={item.disabled ? "true" : undefined}
                                 className="happy-menu__item"
                                 data-danger={item.danger ? "" : undefined}
@@ -103,6 +110,7 @@ export function Menu(props: MenuProps) {
                                     if (!item.disabled) onSelect?.(item.id);
                                 }}
                                 role="menuitem"
+                                title={item.disabled ? item.disabledReason : undefined}
                                 type="button"
                             >
                                 {hasIcons ? (

--- a/packages/happy-desktop-ui/src/TabbedPane.tsx
+++ b/packages/happy-desktop-ui/src/TabbedPane.tsx
@@ -1,6 +1,7 @@
 import { partitionComponentProps } from "./componentProps";
 import { useLayoutEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import type { KeyboardShortcut } from "./keyboardShortcut";
+import type { ContextMenuSelectionResult } from "./ContextMenu";
 import { type MenuItem } from "./Menu";
 import { Tabs, type TabItem, type TabsSize } from "./Tabs";
 import type { TabTransferTarget } from "./tabTransfer";
@@ -26,7 +27,10 @@ export type TabbedPaneProps = {
     onReorder?: (ids: readonly string[]) => void;
     /** Returns the context-menu actions available for one tab. Empty means no menu. */
     tabMenuItems?: (tab: TabItem) => MenuItem[];
-    onTabMenuSelect?: (tab: TabItem, actionId: string) => void;
+    onTabMenuSelect?: (
+        tab: TabItem,
+        actionId: string,
+    ) => ContextMenuSelectionResult | Promise<ContextMenuSelectionResult>;
     /** Where a tab from this pane may be moved to; see `Tabs`. */
     transferTargets?: readonly TabTransferTarget[];
     /** Whether one tab may leave this pane at all. Default: all may. */

--- a/packages/happy-desktop-ui/src/Tabs.tsx
+++ b/packages/happy-desktop-ui/src/Tabs.tsx
@@ -10,10 +10,11 @@ import {
 } from "react";
 import { AvatarBrutalist } from "./AvatarBrutalist";
 import { CountBadge } from "./Badge";
+import { ContextMenu, type ContextMenuSelectionResult } from "./ContextMenu";
 import { haptic } from "./haptics";
 import { Icon, type IconName } from "./Icon";
 import type { KeyboardShortcut } from "./keyboardShortcut";
-import { Menu, type MenuItem } from "./Menu";
+import { type MenuItem } from "./Menu";
 import { ShimmerText } from "./ShimmerText";
 import { Spinner } from "./Spinner";
 import {
@@ -177,7 +178,10 @@ export type TabsProps = {
     onReorder?: (ids: readonly string[]) => void;
     /** Returns the context-menu actions available for one tab. Empty means no menu. */
     tabMenuItems?: (tab: TabItem) => MenuItem[];
-    onTabMenuSelect?: (tab: TabItem, actionId: string) => void;
+    onTabMenuSelect?: (
+        tab: TabItem,
+        actionId: string,
+    ) => ContextMenuSelectionResult | Promise<ContextMenuSelectionResult>;
     /**
      * The other places in the window a tab from this strip may be moved to.
      * Supplying them is what makes a tab leave the strip at all: it can be
@@ -311,41 +315,13 @@ export function Tabs(props: TabsProps) {
     // The context menu is local UI state: it exists between the right click
     // that opened it and the dismissal or selection that closes it, and never
     // becomes product state.
-    const menuRoot = useRef<HTMLDivElement>(null);
     const [tabMenu, setTabMenu] = useState<{
         tab: TabItem;
         items: MenuItem[];
+        opener: HTMLButtonElement;
         x: number;
         y: number;
     }>();
-    // eslint-disable-next-line happy-react/no-layout-effect -- the context menu must measure its rendered height before clamping the fixed popover to the viewport, and global dismissal listeners require imperative cleanup
-    useLayoutEffect(() => {
-        if (!tabMenu) return;
-        const bounds = menuRoot.current?.getBoundingClientRect();
-        if (bounds) {
-            const x = Math.max(8, Math.min(tabMenu.x, window.innerWidth - bounds.width - 8));
-            const y = Math.max(8, Math.min(tabMenu.y, window.innerHeight - bounds.height - 8));
-            if (x !== tabMenu.x || y !== tabMenu.y) {
-                setTabMenu({ ...tabMenu, x, y });
-                return;
-            }
-        }
-        const close = (event: Event) => {
-            if (!menuRoot.current?.contains(event.target as Node)) setTabMenu(undefined);
-        };
-        const closeOnEscape = (event: KeyboardEvent) => {
-            if (event.key === "Escape") setTabMenu(undefined);
-        };
-        const dismiss = () => setTabMenu(undefined);
-        document.addEventListener("pointerdown", close);
-        document.addEventListener("keydown", closeOnEscape);
-        window.addEventListener("resize", dismiss);
-        return () => {
-            document.removeEventListener("pointerdown", close);
-            document.removeEventListener("keydown", closeOnEscape);
-            window.removeEventListener("resize", dismiss);
-        };
-    }, [tabMenu]);
     const openTabMenu = (tab: TabItem, event: MouseEvent<HTMLButtonElement>) => {
         const owned = local.tabMenuItems?.(tab) ?? [];
         // Moving the tab is this component's own act, so it offers it itself
@@ -370,11 +346,15 @@ export function Tabs(props: TabsProps) {
             return;
         }
         event.preventDefault();
+        const bounds = event.currentTarget.getBoundingClientRect();
+        const pointer = event.clientX !== 0 || event.clientY !== 0;
+        event.currentTarget.focus({ preventScroll: true });
         setTabMenu({
             items,
+            opener: event.currentTarget,
             tab,
-            x: event.clientX,
-            y: event.clientY,
+            x: pointer ? event.clientX : bounds.left + 24,
+            y: pointer ? event.clientY : bounds.bottom,
         });
     };
     // The drag is local UI state: it exists only between pointer-down and
@@ -780,30 +760,28 @@ export function Tabs(props: TabsProps) {
                 </span>
             ))}
             {tabMenu ? (
-                <div
-                    className="happy-tabs__menu"
-                    data-happy-desktop-ui="tabs-menu"
-                    ref={menuRoot}
-                    style={{ left: tabMenu.x, top: tabMenu.y }}
-                >
-                    <Menu
-                        items={tabMenu.items}
-                        onSelect={(actionId) => {
-                            const tab = tabMenu.tab;
-                            setTabMenu(undefined);
-                            if (actionId.startsWith(TRANSFER_MENU_PREFIX)) {
-                                const zone = actionId.slice(TRANSFER_MENU_PREFIX.length);
-                                const target = targets().find(
-                                    (candidate) => candidate.zone === zone,
-                                );
-                                if (target) transferRun(tab, target, true);
-                                return;
-                            }
-                            local.onTabMenuSelect?.(tab, actionId);
-                        }}
-                        width={216}
-                    />
-                </div>
+                <ContextMenu
+                    items={tabMenu.items}
+                    key={`${tabMenu.tab.id}:${String(tabMenu.x)}:${String(tabMenu.y)}`}
+                    onDismiss={(reason) => {
+                        const opener = tabMenu.opener;
+                        setTabMenu(undefined);
+                        if (reason === "escape" && opener.isConnected)
+                            opener.focus({ preventScroll: true });
+                    }}
+                    onSelect={(actionId) => {
+                        const tab = tabMenu.tab;
+                        if (actionId.startsWith(TRANSFER_MENU_PREFIX)) {
+                            const zone = actionId.slice(TRANSFER_MENU_PREFIX.length);
+                            const target = targets().find((candidate) => candidate.zone === zone);
+                            if (target) transferRun(tab, target, true);
+                            return;
+                        }
+                        return local.onTabMenuSelect?.(tab, actionId);
+                    }}
+                    placement={{ x: tabMenu.x, y: tabMenu.y }}
+                    width={216}
+                />
             ) : null}
         </div>
     );

--- a/packages/happy-desktop-ui/src/index.ts
+++ b/packages/happy-desktop-ui/src/index.ts
@@ -36,6 +36,14 @@ export {
 export { TurnSummary, type TurnSummaryProps } from "./TurnSummary";
 export { Tooltip, type TooltipPlacement, type TooltipProps } from "./Tooltip";
 export { CopyButton, type CopyButtonProps } from "./CopyButton";
+export {
+    ContextMenu,
+    type ContextMenuDismissReason,
+    type ContextMenuPlacement,
+    type ContextMenuProps,
+    type ContextMenuSelectionFeedback,
+    type ContextMenuSelectionResult,
+} from "./ContextMenu";
 export { ScrollingText, type ScrollingTextProps } from "./ScrollingText";
 export { TypedText, type TypedTextProps } from "./TypedText";
 export {
@@ -141,6 +149,7 @@ export {
     FileTreeFamilyIcon,
     fileTreeFamily,
     type FileTreeFamily,
+    type FileTreeContextSelection,
     type FileTreeGitStatus,
     type FileTreeNode,
     type FileTreeProps,

--- a/packages/happy-desktop-ui/src/styles.css
+++ b/packages/happy-desktop-ui/src/styles.css
@@ -69,6 +69,7 @@
 @import "./styles/command-palette.css";
 @import "./styles/command-palette-results.css";
 @import "./styles/command-picker.css";
+@import "./styles/context-menu.css";
 @import "./styles/quick-actions.css";
 @import "./styles/lightbox.css";
 @import "./styles/form-row.css";

--- a/packages/happy-desktop-ui/src/styles/context-menu.css
+++ b/packages/happy-desktop-ui/src/styles/context-menu.css
@@ -1,0 +1,12 @@
+/* A context menu rides the viewport rather than its clipped row or tab strip. */
+.happy-context-menu {
+    position: fixed;
+    z-index: 40;
+}
+
+/* The rows already scroll inside Menu; cap the card so every command remains
+   reachable even when many installed applications are offered. */
+.happy-context-menu > .happy-menu {
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+}

--- a/packages/happy-desktop-ui/src/styles/tabs.css
+++ b/packages/happy-desktop-ui/src/styles/tabs.css
@@ -15,14 +15,6 @@
     font-family: var(--happy-font-ui);
 }
 
-/* The context menu rides the viewport, not the strip: the bar clips and
-   scrolls horizontally, and a popover inside that scrollport would be cut off
-   at its edge. */
-.happy-tabs__menu {
-    position: fixed;
-    z-index: 40;
-}
-
 .happy-tabs__tab {
     position: relative;
     display: inline-flex;


### PR DESCRIPTION
## Summary

- add a shared, keyboard-accessible context menu for file/folder rows and reuse it on open file tabs
- offer Open, Show in Finder, installed Open in targets, and canonical/relative path copy with multi-selection semantics and inline success feedback
- resolve native actions from daemon-authoritative workspace roots while explicitly refusing remote-owned, Docker, absolute, and escaping paths

## Verification

- formatting, lint, typecheck, and production builds for state, UI, app, and Electron packages
- Electron test suite: 7 files, 22 tests passed
- Blueprint in Chrome at 2×: pointer and Shift+F10 menus, arrow navigation, Escape focus restoration, exact multi-selection clipboard contents, expiring feedback, viewport clamping, tab-menu reuse, and native-menu fallthrough

Closes #18
