### PR TITLE
Prevent renderer OOM during streaming

### DIFF
--- a/packages/happy-desktop-electron/sources/renderer/happyProfilerBootstrap.ts
+++ b/packages/happy-desktop-electron/sources/renderer/happyProfilerBootstrap.ts
@@ -6,6 +6,27 @@ import {
     type DesktopReactDevtoolsCommand,
 } from "../shared/desktopProfiler";
 
+let performanceMeasureDrain: PerformanceObserver | undefined;
+
+/**
+ * React DOM's profiling renderer emits a `PerformanceMeasure` for every
+ * component render whether or not React DevTools is actively recording.
+ * Chromium retains those entries (including changed-prop detail) until they
+ * are explicitly cleared. A streaming conversation can otherwise leave
+ * hundreds of thousands of entries in the renderer and eventually make the
+ * next `performance.measure` fail while cloning its detail out of memory.
+ *
+ * React DevTools sends its profile through the custom backend below, so its
+ * artifact does not depend on entries remaining in the browser's Performance
+ * Timeline after observers have received them.
+ */
+function performanceMeasureRetentionBound(): void {
+    if (performanceMeasureDrain || typeof PerformanceObserver === "undefined") return;
+    performance.clearMeasures();
+    performanceMeasureDrain = new PerformanceObserver(() => performance.clearMeasures());
+    performanceMeasureDrain.observe({ entryTypes: ["measure"] });
+}
+
 /**
  * The profile HTML entry calls this synchronously before it dynamically imports
  * renderer.tsx. React DOM reads __REACT_DEVTOOLS_GLOBAL_HOOK__ while its
@@ -16,6 +37,7 @@ import {
  * do not import this entry and retain the ordinary React DOM renderer.
  */
 export function happyProfilerBootstrap(): void {
+    performanceMeasureRetentionBound();
     const bridge = window.happyDesktop;
     const hookAlreadyInstalled = Object.prototype.hasOwnProperty.call(
         window as object,

--- a/packages/happy-desktop-state/src/happyAgentConnection/connectHappyAgent.ts
+++ b/packages/happy-desktop-state/src/happyAgentConnection/connectHappyAgent.ts
@@ -31,6 +31,7 @@ import { projectRegistrationError } from "./errors.js";
 import { deepEqual } from "../happyAgent/happyAgentSupport.js";
 import type { HappyAgentDebugLogInput } from "../happyAgent/happyAgentDebugLogStore.js";
 import {
+    agentGroupProjectionChanged,
     applyChanges,
     defaultMode,
     elementsReuse,
@@ -466,6 +467,7 @@ export function connectHappyAgent(options: ConnectHappyAgentOptions): HappyAgent
         current.version.localeCompare(updated.version) <= 0;
 
     const replaceAgent = (agent: Agent): void => {
+        const previous = agentOf(agent.id);
         groupsStore.setState((current) => ({
             workspaces: current.workspaces.map((workspace) =>
                 workspace.id === agent.workspaceId ||
@@ -504,7 +506,7 @@ export function connectHappyAgent(options: ConnectHappyAgentOptions): HappyAgent
             });
             publishSession(parent);
         }
-        publishGroups();
+        if (previous === undefined || agentGroupProjectionChanged(previous, agent)) publishGroups();
     };
 
     const adoptAgent = (agent: Agent): boolean => {

--- a/packages/happy-desktop-state/src/happyAgentConnection/projection.ts
+++ b/packages/happy-desktop-state/src/happyAgentConnection/projection.ts
@@ -557,6 +557,38 @@ function projectWorkspace(
     };
 }
 
+/**
+ * Whether replacing an agent changes anything the project/bot catalog projects.
+ *
+ * A running agent advances `updatedAt` for every streamed event, while the
+ * catalog needs that timestamp only once the agent is idle again. Publishing
+ * every intermediate timestamp makes unrelated directory and sidebar readers
+ * reconcile once per token. The focused session still receives the complete
+ * agent through its own subscription; the transition back to idle publishes
+ * the newest timestamp to the catalog.
+ *
+ * Keep this comparison beside `projectAgent`: every agent field projected into
+ * `GroupSession` or `unreadOf` must be represented here.
+ */
+export function agentGroupProjectionChanged(previous: Agent, next: Agent): boolean {
+    const previousRunning = previous.status !== "idle";
+    const nextRunning = next.status !== "idle";
+    return (
+        previous.id !== next.id ||
+        previous.workspaceId !== next.workspaceId ||
+        previous.archivedAt !== next.archivedAt ||
+        previous.createdAt !== next.createdAt ||
+        previous.orderKey !== next.orderKey ||
+        previous.parentAgentId !== next.parentAgentId ||
+        previousRunning !== nextRunning ||
+        previous.subagents.running !== next.subagents.running ||
+        previous.title !== next.title ||
+        previous.unread?.reason !== next.unread?.reason ||
+        previous.unread?.since !== next.unread?.since ||
+        (!previousRunning && !nextRunning && previous.updatedAt !== next.updatedAt)
+    );
+}
+
 function projectAgent(
     agent: Agent,
     workspace: Workspace | undefined,


### PR DESCRIPTION
## Summary

- stop running-session `updatedAt` churn from republishing the project/bot catalog for every streamed event
- keep catalog-visible transitions (status, title, unread, archive/order/workspace, subagent activity, and the final idle timestamp) immediate
- drain React profiling `PerformanceMeasure` entries after observer delivery so changed-prop details cannot accumulate until Chromium crashes

The focused session still receives every complete agent update through its own subscription, preserving live transcript and activity behavior without forcing unrelated directory/sidebar reconciliation.

Closes #23

## Verification

- `pnpm --dir packages/happy-desktop-state typecheck`
- `pnpm --dir packages/happy-desktop-electron exec tsc -p tsconfig.json --noEmit`
- `node scripts/check-react-boundaries.mjs`
- focused `oxlint` and `oxfmt --check` on all changed files
- `pnpm --dir packages/happy-desktop-electron build:profile` under the repository's required Node 24 toolchain
- isolated browser-local profile run against an actively streaming session:
  - 3,657 React measures observed over 20 seconds
  - 0 measures retained in the Performance Timeline at every sample
  - no page or console errors
  - `AppShell` fell from about 140 measurements/sec in the failing reproduction to about 2/sec while conversation rows continued updating

No new test files were added, following the repository instruction to verify changes by building and running unless tests are explicitly requested.
